### PR TITLE
Vcs datasource

### DIFF
--- a/examples/data-sources/vcs_example/data-source.tf
+++ b/examples/data-sources/vcs_example/data-source.tf
@@ -1,0 +1,8 @@
+data "terrakube_organization" "org" {
+  name = "simple"
+}
+
+data "terrakube_vcs" "vcs" {
+  name = "sample"
+  organization_id = data.terrakube_organization.org.id
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,24 +8,5 @@ terraform {
 
 provider "terrakube" {
   endpoint = "http://terrakube-api.minikube.net"
-  token    = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXJyYWt1YmUiLCJzdWIiOiJMZXN0ZXIgKFRva2VuKSIsImF1ZCI6IlRlcnJha3ViZSIsImp0aSI6IjI5ZmZhMzc5LTE1NWUtNDhlYS04MDJhLTMwZWUyZmRlMjQwOSIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6Ikxlc3RlciAoVG9rZW4pIiwiZ3JvdXBzIjpbIlRFUlJBS1VCRV9BRE1JTiIsIlRFUlJBS1VCRV9ERVZFTE9QRVJTIl0sImlhdCI6MTY5NTc2NjUwMSwiZXhwIjoxNjk2MzcxMzAxfQ._cDRy4oH11OcWTRFiyxZhTENODwhBStmWwqrGj4yPRs"
-}
-
-data "terrakube_organization" "org" {
-  name = "simple"
-}
-
-data "terrakube_vcs" "vcs" {
-  name = "sample"
-  organization_id = data.terrakube_organization.org.id
-}
-
-resource "terrakube_team" "team" {
-  name             = "TERRAKUBE_SUPER_ADMIN"
-  organization_id  = data.terrakube_organization.org.id
-  manage_workspace = false
-  manage_module    = false
-  manage_provider  = true
-  manage_vcs       = true
-  manage_template  = true
+  token    = "XXX"
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,5 +8,24 @@ terraform {
 
 provider "terrakube" {
   endpoint = "http://terrakube-api.minikube.net"
-  token    = "XXX"
+  token    = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXJyYWt1YmUiLCJzdWIiOiJMZXN0ZXIgKFRva2VuKSIsImF1ZCI6IlRlcnJha3ViZSIsImp0aSI6IjI5ZmZhMzc5LTE1NWUtNDhlYS04MDJhLTMwZWUyZmRlMjQwOSIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6Ikxlc3RlciAoVG9rZW4pIiwiZ3JvdXBzIjpbIlRFUlJBS1VCRV9BRE1JTiIsIlRFUlJBS1VCRV9ERVZFTE9QRVJTIl0sImlhdCI6MTY5NTc2NjUwMSwiZXhwIjoxNjk2MzcxMzAxfQ._cDRy4oH11OcWTRFiyxZhTENODwhBStmWwqrGj4yPRs"
+}
+
+data "terrakube_organization" "org" {
+  name = "simple"
+}
+
+data "terrakube_vcs" "vcs" {
+  name = "sample"
+  organization_id = data.terrakube_organization.org.id
+}
+
+resource "terrakube_team" "team" {
+  name             = "TERRAKUBE_SUPER_ADMIN"
+  organization_id  = data.terrakube_organization.org.id
+  manage_workspace = false
+  manage_module    = false
+  manage_provider  = true
+  manage_vcs       = true
+  manage_template  = true
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -19,3 +19,9 @@ type TeamEntity struct {
 	ManageVcs       bool   `jsonapi:"attr,manageVcs"`
 	ManageTemplate  bool   `jsonapi:"attr,manageTemplate"`
 }
+
+type VcsEntity struct {
+	ID          string `jsonapi:"primary,vcs"`
+	Name        string `jsonapi:"attr,name"`
+	Description string `jsonapi:"attr,description"`
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -168,5 +168,6 @@ func (p *TerrakubeProvider) Resources(ctx context.Context) []func() resource.Res
 func (p *TerrakubeProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
 		NewOrganizationDataSource,
+		NewVcsDataSource,
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+)
+
+const (
+	// providerConfig is a shared configuration to combine with the actual
+	// test configuration so the HashiCups client is properly configured.
+	// It is also possible to use the HASHICUPS_ environment variables instead,
+	// such as updating the Makefile and running the testing through that tool.
+	providerConfig = `
+provider "terrakube" {
+  endpoint = "http://terrakube-api.minikube.net"
+  token    = "test1234"
+}
+`
+)
+
+var (
+	testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
+		"terrakube": providerserver.NewProtocol6WithError(New("test")()),
+	}
+)

--- a/internal/provider/vcs_data_source.go
+++ b/internal/provider/vcs_data_source.go
@@ -1,0 +1,131 @@
+package provider
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/google/jsonapi"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"terraform-provider-terrakube/internal/client"
+)
+
+var (
+	_ datasource.DataSource              = &VcsDataSource{}
+	_ datasource.DataSourceWithConfigure = &VcsDataSource{}
+)
+
+type VcsDataSourceModel struct {
+	ID             types.String `tfsdk:"id"`
+	OrganizationId types.String `tfsdk:"organization_id"`
+	Name           types.String `tfsdk:"name"`
+	Description    types.String `tfsdk:"description"`
+}
+
+type VcsDataSource struct {
+	client   *http.Client
+	endpoint string
+	token    string
+}
+
+func NewVcsDataSource() datasource.DataSource {
+	return &VcsDataSource{}
+}
+
+func (d *VcsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, res *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	providerData, ok := req.ProviderData.(*TerrakubeConnectionData)
+	if !ok {
+		res.Diagnostics.AddError(
+			"Unexpected Vcs Data Source Configure Type",
+			fmt.Sprintf("Expected *TerrakubeConnectionData got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	client := http.Client{Transport: customTransport}
+
+	d.client = &client
+	d.endpoint = providerData.Endpoint
+	d.token = providerData.Token
+
+	tflog.Info(ctx, "Creating Vcs datasource")
+}
+
+func (d *VcsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_vcs"
+}
+
+func (d *VcsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Vcs Id",
+			},
+			"organization_id": schema.StringAttribute{
+				Required:    true,
+				Description: "Terrakube organization id",
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Vcs Name",
+			},
+			"description": schema.StringAttribute{
+				Computed:    true,
+				Description: "Vcs description information",
+			},
+		},
+	}
+}
+
+func (d *VcsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state VcsDataSourceModel
+
+	req.Config.Get(ctx, &state)
+
+	requestVcs, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/vcs?filter[vcs]=name==%s", d.endpoint, state.OrganizationId.ValueString(), state.Name.ValueString()), nil)
+	requestVcs.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
+	requestVcs.Header.Add("Content-Type", "application/vnd.api+json")
+	if err != nil {
+		tflog.Error(ctx, "Error creating vcs datasource request")
+	}
+
+	responseVcs, err := d.client.Do(requestVcs)
+	if err != nil {
+		tflog.Error(ctx, "Error executing vcs datasource request")
+	}
+
+	body, err := io.ReadAll(responseVcs.Body)
+	if err != nil {
+		tflog.Error(ctx, "Error reading vcs response")
+	}
+
+	var vcss []interface{}
+
+	vcss, err = jsonapi.UnmarshalManyPayload(strings.NewReader(string(body)), reflect.TypeOf(new(client.VcsEntity)))
+
+	for _, vcs := range vcss {
+		data, _ := vcs.(*client.VcsEntity)
+		state.ID = types.StringValue(data.ID)
+		state.Description = types.StringValue(data.Description)
+	}
+
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}


### PR DESCRIPTION
Adding support to handel vcs datasource:

```terraform
data "terrakube_organization" "org" {
  name = "simple"
}

data "terrakube_vcs" "vcs" {
  name = "sample"
  organization_id = data.terrakube_organization.org.id
}
```

Fixes #1 