### PR TITLE
Ssh datasource

### DIFF
--- a/examples/data-sources/ssh_example/data-source.tf
+++ b/examples/data-sources/ssh_example/data-source.tf
@@ -1,0 +1,8 @@
+data "terrakube_organization" "org" {
+  name = "simple"
+}
+
+data "terrakube_ssh" "ssh" {
+  name = "sample"
+  organization_id = data.terrakube_organization.org.id
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,5 +8,29 @@ terraform {
 
 provider "terrakube" {
   endpoint = "http://terrakube-api.minikube.net"
-  token    = "XXX"
+  token    = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXJyYWt1YmUiLCJzdWIiOiJMZXN0ZXIgKFRva2VuKSIsImF1ZCI6IlRlcnJha3ViZSIsImp0aSI6IjI5ZmZhMzc5LTE1NWUtNDhlYS04MDJhLTMwZWUyZmRlMjQwOSIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6Ikxlc3RlciAoVG9rZW4pIiwiZ3JvdXBzIjpbIlRFUlJBS1VCRV9BRE1JTiIsIlRFUlJBS1VCRV9ERVZFTE9QRVJTIl0sImlhdCI6MTY5NTc2NjUwMSwiZXhwIjoxNjk2MzcxMzAxfQ._cDRy4oH11OcWTRFiyxZhTENODwhBStmWwqrGj4yPRs"
+}
+
+data "terrakube_organization" "org" {
+  name = "simple"
+}
+
+data "terrakube_vcs" "vcs" {
+  name = "sample"
+  organization_id = data.terrakube_organization.org.id
+}
+
+data "terrakube_ssh" "ssh" {
+  name = "hola"
+  organization_id = data.terrakube_organization.org.id
+}
+
+resource "terrakube_team" "team" {
+  name             = "TERRAKUBE_SUPER_ADMIN"
+  organization_id  = data.terrakube_organization.org.id
+  manage_workspace = false
+  manage_module    = false
+  manage_provider  = true
+  manage_vcs       = true
+  manage_template  = true
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -8,29 +8,5 @@ terraform {
 
 provider "terrakube" {
   endpoint = "http://terrakube-api.minikube.net"
-  token    = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXJyYWt1YmUiLCJzdWIiOiJMZXN0ZXIgKFRva2VuKSIsImF1ZCI6IlRlcnJha3ViZSIsImp0aSI6IjI5ZmZhMzc5LTE1NWUtNDhlYS04MDJhLTMwZWUyZmRlMjQwOSIsImVtYWlsIjoiYWRtaW5AZXhhbXBsZS5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwibmFtZSI6Ikxlc3RlciAoVG9rZW4pIiwiZ3JvdXBzIjpbIlRFUlJBS1VCRV9BRE1JTiIsIlRFUlJBS1VCRV9ERVZFTE9QRVJTIl0sImlhdCI6MTY5NTc2NjUwMSwiZXhwIjoxNjk2MzcxMzAxfQ._cDRy4oH11OcWTRFiyxZhTENODwhBStmWwqrGj4yPRs"
-}
-
-data "terrakube_organization" "org" {
-  name = "simple"
-}
-
-data "terrakube_vcs" "vcs" {
-  name = "sample"
-  organization_id = data.terrakube_organization.org.id
-}
-
-data "terrakube_ssh" "ssh" {
-  name = "hola"
-  organization_id = data.terrakube_organization.org.id
-}
-
-resource "terrakube_team" "team" {
-  name             = "TERRAKUBE_SUPER_ADMIN"
-  organization_id  = data.terrakube_organization.org.id
-  manage_workspace = false
-  manage_module    = false
-  manage_provider  = true
-  manage_vcs       = true
-  manage_template  = true
+  token    = "XXX"
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -25,3 +25,9 @@ type VcsEntity struct {
 	Name        string `jsonapi:"attr,name"`
 	Description string `jsonapi:"attr,description"`
 }
+
+type SshEntity struct {
+	ID          string `jsonapi:"primary,ssh"`
+	Name        string `jsonapi:"attr,name"`
+	Description string `jsonapi:"attr,description"`
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -169,5 +169,6 @@ func (p *TerrakubeProvider) DataSources(ctx context.Context) []func() datasource
 	return []func() datasource.DataSource{
 		NewOrganizationDataSource,
 		NewVcsDataSource,
+		NewSshDataSource,
 	}
 }

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -292,7 +292,7 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	bodyResponse, err = io.ReadAll(teamResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, "Error reading team resource response")
+		resp.Diagnostics.AddError("Error reading team resource response body", fmt.Sprintf("Error reading team resource response body: %s", err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})


### PR DESCRIPTION
Adding support to handle ssh datasource:

```terraform
data "terrakube_organization" "org" {
  name = "simple"
}

data "terrakube_ssh" "ssh" {
  name = "hola"
  organization_id = data.terrakube_organization.org.id
}
```

Fix #7 