### PR TITLE
Add support to add ssh-id and vcs-id in module resource

### DIFF
--- a/examples/resources/module_example/resource.tf
+++ b/examples/resources/module_example/resource.tf
@@ -5,3 +5,21 @@ resource "terrakube_module" "module" {
   provider_name   = "aws"
   source          = "https://github.com/terraform-aws-modules/terraform-aws-vpc.git"
 }
+
+resource "terrakube_module" "module" {
+  name            = "vpc_private"
+  organization_id = data.terrakube_ssh.ssh.organization_id
+  description     = "cloudposse module"
+  provider_name   = "aws"
+  source          = "https://github.com/terraform-aws-modules/terraform-aws-vpc.git"
+  vcs_id          = data.terrakube_vcs.vcs.id
+}
+
+resource "terrakube_module" "module" {
+  name            = "vpc_private_ssh"
+  organization_id = data.terrakube_ssh.ssh.organization_id
+  description     = "cloudposse module"
+  provider_name   = "aws"
+  source          = "https://github.com/terraform-aws-modules/terraform-aws-vpc.git"
+  ssh_id          = data.terrakube_ssh.ssh.id
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -33,9 +33,11 @@ type SshEntity struct {
 }
 
 type ModuleEntity struct {
-	ID          string `jsonapi:"primary,module"`
-	Name        string `jsonapi:"attr,name"`
-	Description string `jsonapi:"attr,description"`
-	Provider    string `jsonapi:"attr,provider"`
-	Source      string `jsonapi:"attr,source"`
+	ID          string     `jsonapi:"primary,module"`
+	Name        string     `jsonapi:"attr,name"`
+	Description string     `jsonapi:"attr,description"`
+	Provider    string     `jsonapi:"attr,provider"`
+	Source      string     `jsonapi:"attr,source"`
+	Vcs         *VcsEntity `jsonapi:"relation,vcs,omitempty"`
+	Ssh         *SshEntity `jsonapi:"relation,ssh,omitempty"`
 }


### PR DESCRIPTION
Adding support to manage modules with private connections.

```terraform
resource "terrakube_module" "module" {
  name            = "vpc_private"
  organization_id = data.terrakube_ssh.ssh.organization_id
  description     = "cloudposse module"
  provider_name   = "aws"
  source          = "https://github.com/terraform-aws-modules/terraform-aws-vpc.git"
  vcs_id          = data.terrakube_vcs.vcs.id
}

resource "terrakube_module" "module" {
  name            = "vpc_private_ssh"
  organization_id = data.terrakube_ssh.ssh.organization_id
  description     = "cloudposse module"
  provider_name   = "aws"
  source          = "https://github.com/terraform-aws-modules/terraform-aws-vpc.git"
  ssh_id          = data.terrakube_ssh.ssh.id
}
```