### PR TITLE
Fix logic to create/delete/update sensitive variables

### DIFF
--- a/internal/provider/organization_variable_resource.go
+++ b/internal/provider/organization_variable_resource.go
@@ -172,7 +172,7 @@ func (r *OrganizationVariableResource) Create(ctx context.Context, req resource.
 	organizationVariable := &client.OrganizationVariableEntity{}
 
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), organizationVariable)
-
+	tflog.Info(ctx, string(bodyResponse))
 	if err != nil {
 		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response: %s", err))
 		return
@@ -180,8 +180,16 @@ func (r *OrganizationVariableResource) Create(ctx context.Context, req resource.
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
+	b := *organizationVariable.Sensitive
+	if b == true {
+		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the plan for sensitive=true...")
+		plan.Value = types.StringValue(plan.Value.ValueString())
+	} else {
+		tflog.Info(ctx, "Variable value is included in response...")
+		plan.Value = types.StringValue(organizationVariable.Value)
+	}
+
 	plan.Key = types.StringValue(organizationVariable.Key)
-	plan.Value = types.StringValue(organizationVariable.Value)
 	plan.Description = types.StringValue(organizationVariable.Description)
 	plan.Category = types.StringValue(organizationVariable.Category)
 	plan.Sensitive = types.BoolValue(*organizationVariable.Sensitive)
@@ -231,8 +239,16 @@ func (r *OrganizationVariableResource) Read(ctx context.Context, req resource.Re
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
+	b := *organizationVariable.Sensitive
+	if b == true {
+		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the current state value")
+		state.Value = types.StringValue(state.Value.ValueString())
+	} else {
+		tflog.Info(ctx, "Variable value is included in response...")
+		state.Value = types.StringValue(organizationVariable.Value)
+	}
+
 	state.Key = types.StringValue(organizationVariable.Key)
-	state.Value = types.StringValue(organizationVariable.Value)
 	state.Description = types.StringValue(organizationVariable.Description)
 	state.Category = types.StringValue(organizationVariable.Category)
 	state.Sensitive = types.BoolValue(*organizationVariable.Sensitive)
@@ -330,7 +346,15 @@ func (r *OrganizationVariableResource) Update(ctx context.Context, req resource.
 
 	plan.ID = types.StringValue(state.ID.ValueString())
 	plan.Key = types.StringValue(organizationVariable.Key)
-	plan.Value = types.StringValue(organizationVariable.Value)
+	b := *organizationVariable.Sensitive
+	if b == true {
+		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the plan for sensitive=true...")
+		plan.Value = types.StringValue(plan.Value.ValueString())
+	} else {
+		tflog.Info(ctx, "Variable value is included in response...")
+		plan.Value = types.StringValue(organizationVariable.Value)
+	}
+
 	plan.Description = types.StringValue(organizationVariable.Description)
 	plan.Category = types.StringValue(organizationVariable.Category)
 	plan.Sensitive = types.BoolValue(*organizationVariable.Sensitive)

--- a/internal/provider/organization_variable_resource.go
+++ b/internal/provider/organization_variable_resource.go
@@ -180,8 +180,7 @@ func (r *OrganizationVariableResource) Create(ctx context.Context, req resource.
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
-	b := *organizationVariable.Sensitive
-	if b == true {
+	if *organizationVariable.Sensitive {
 		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the plan for sensitive=true...")
 		plan.Value = types.StringValue(plan.Value.ValueString())
 	} else {
@@ -239,8 +238,7 @@ func (r *OrganizationVariableResource) Read(ctx context.Context, req resource.Re
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
-	b := *organizationVariable.Sensitive
-	if b == true {
+	if *organizationVariable.Sensitive {
 		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the current state value")
 		state.Value = types.StringValue(state.Value.ValueString())
 	} else {
@@ -346,8 +344,8 @@ func (r *OrganizationVariableResource) Update(ctx context.Context, req resource.
 
 	plan.ID = types.StringValue(state.ID.ValueString())
 	plan.Key = types.StringValue(organizationVariable.Key)
-	b := *organizationVariable.Sensitive
-	if b == true {
+
+	if *organizationVariable.Sensitive {
 		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the plan for sensitive=true...")
 		plan.Value = types.StringValue(plan.Value.ValueString())
 	} else {

--- a/internal/provider/workspace_variable_resource.go
+++ b/internal/provider/workspace_variable_resource.go
@@ -184,8 +184,16 @@ func (r *WorkspaceVariableResource) Create(ctx context.Context, req resource.Cre
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
+	b := workspaceVariable.Sensitive
+	if b == true {
+		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the plan for sensitive=true...")
+		plan.Value = types.StringValue(plan.Value.ValueString())
+	} else {
+		tflog.Info(ctx, "Variable value is included in response...")
+		plan.Value = types.StringValue(workspaceVariable.Value)
+	}
+
 	plan.Key = types.StringValue(workspaceVariable.Key)
-	plan.Value = types.StringValue(workspaceVariable.Value)
 	plan.Description = types.StringValue(workspaceVariable.Description)
 	plan.Category = types.StringValue(workspaceVariable.Category)
 	plan.Sensitive = types.BoolValue(workspaceVariable.Sensitive)
@@ -235,8 +243,16 @@ func (r *WorkspaceVariableResource) Read(ctx context.Context, req resource.ReadR
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
+	b := workspaceVariable.Sensitive
+	if b == true {
+		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the current state value")
+		state.Value = types.StringValue(state.Value.ValueString())
+	} else {
+		tflog.Info(ctx, "Variable value is included in response...")
+		state.Value = types.StringValue(workspaceVariable.Value)
+	}
+
 	state.Key = types.StringValue(workspaceVariable.Key)
-	state.Value = types.StringValue(workspaceVariable.Value)
 	state.Description = types.StringValue(workspaceVariable.Description)
 	state.Category = types.StringValue(workspaceVariable.Category)
 	state.Sensitive = types.BoolValue(workspaceVariable.Sensitive)
@@ -331,9 +347,17 @@ func (r *WorkspaceVariableResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
+	b := workspaceVariable.Sensitive
+	if b == true {
+		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the plan for sensitive=true...")
+		plan.Value = types.StringValue(plan.Value.ValueString())
+	} else {
+		tflog.Info(ctx, "Variable value is included in response...")
+		plan.Value = types.StringValue(workspaceVariable.Value)
+	}
+
 	plan.ID = types.StringValue(state.ID.ValueString())
 	plan.Key = types.StringValue(workspaceVariable.Key)
-	plan.Value = types.StringValue(workspaceVariable.Value)
 	plan.Description = types.StringValue(workspaceVariable.Description)
 	plan.Category = types.StringValue(workspaceVariable.Category)
 	plan.Sensitive = types.BoolValue(workspaceVariable.Sensitive)

--- a/internal/provider/workspace_variable_resource.go
+++ b/internal/provider/workspace_variable_resource.go
@@ -184,8 +184,7 @@ func (r *WorkspaceVariableResource) Create(ctx context.Context, req resource.Cre
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
-	b := workspaceVariable.Sensitive
-	if b == true {
+	if workspaceVariable.Sensitive {
 		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the plan for sensitive=true...")
 		plan.Value = types.StringValue(plan.Value.ValueString())
 	} else {
@@ -243,8 +242,7 @@ func (r *WorkspaceVariableResource) Read(ctx context.Context, req resource.ReadR
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
-	b := workspaceVariable.Sensitive
-	if b == true {
+	if workspaceVariable.Sensitive {
 		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the current state value")
 		state.Value = types.StringValue(state.Value.ValueString())
 	} else {
@@ -347,8 +345,7 @@ func (r *WorkspaceVariableResource) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	b := workspaceVariable.Sensitive
-	if b == true {
+	if workspaceVariable.Sensitive {
 		tflog.Info(ctx, "Variable value is not included in response, setting values the same as the plan for sensitive=true...")
 		plan.Value = types.StringValue(plan.Value.ValueString())
 	} else {


### PR DESCRIPTION
Fix internal logic when creating resources with "sensitive=true" like the following:

```terraform
resource "terrakube_organization_variable" "sample0" {
  organization_id = data.terrakube_organization.org.id
  key             = "org-sensitive"
  value           = "sensitive"
  description     = "sample"
  category        = "ENV"
  sensitive       = true
  hcl             = false
}

resource "terrakube_workspace_variable" "sample1" {
  organization_id = data.terrakube_organization.org.id
  workspace_id    = terrakube_workspace_cli.sample1.id
  key             = "workspace-sensitive"
  value           = "sensitive"
  description     = "Sample"
  category        = "ENV"
  sensitive       = true
  hcl             = false
}
```

Fix #36 