### PR TITLE
Add support to use a vcs_id in a workspace_vcs resource

### DIFF
--- a/docs/resources/workspace_vcs.md
+++ b/docs/resources/workspace_vcs.md
@@ -27,6 +27,10 @@ description: |-
 - `organization_id` (String) Terrakube organization id
 - `repository` (String) Workspace VCS repository
 
+### Optional
+
+- `vcs_id` (String) VCS connection ID for private workspaces
+
 ### Read-Only
 
 - `id` (String) Workspace CLI Id

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -23,16 +23,17 @@ type TeamEntity struct {
 }
 
 type WorkspaceEntity struct {
-	ID            string `jsonapi:"primary,workspace"`
-	Name          string `jsonapi:"attr,name"`
-	Description   string `jsonapi:"attr,description"`
-	Source        string `jsonapi:"attr,source"`
-	Branch        string `jsonapi:"attr,branch"`
-	Folder        string `jsonapi:"attr,folder"`
-	IaCType       string `jsonapi:"attr,iacType"`
-	IaCVersion    string `jsonapi:"attr,terraformVersion"`
-	ExecutionMode string `jsonapi:"attr,executionMode"`
-	Deleted       bool   `jsonapi:"attr,deleted"`
+	ID            string     `jsonapi:"primary,workspace"`
+	Name          string     `jsonapi:"attr,name"`
+	Description   string     `jsonapi:"attr,description"`
+	Source        string     `jsonapi:"attr,source"`
+	Branch        string     `jsonapi:"attr,branch"`
+	Folder        string     `jsonapi:"attr,folder"`
+	IaCType       string     `jsonapi:"attr,iacType"`
+	IaCVersion    string     `jsonapi:"attr,terraformVersion"`
+	ExecutionMode string     `jsonapi:"attr,executionMode"`
+	Deleted       bool       `jsonapi:"attr,deleted"`
+	Vcs           *VcsEntity `jsonapi:"relation,vcs,omitempty"`
 }
 
 type WorkspaceVariableEntity struct {


### PR DESCRIPTION
Add support to use vcs_id in workspace_vcs resource like the following:

```terraform
resource "terrakube_workspace_vcs" "vcs2" {
  organization_id = data.terrakube_organization.org.id
  name            = "vcs-workspace2"
  description     = "sample2"
  execution_mode  = "remote"
  repository      = "https://github.com/alfespa17/terraform-module-private.git"
  branch          = "main"
  iac_type        = "terraform"
  folder          = "/module"
  iac_version     = "1.5.7"
  vcs_id          = "c5f1b1f6-8e68-4c4d-b688-9fac563b611d"
}
```