### PR TITLE
fix: Update schema for `terrakube_vcs` data source

### DIFF
--- a/docs/data-sources/vcs.md
+++ b/docs/data-sources/vcs.md
@@ -22,5 +22,9 @@ description: |-
 
 ### Read-Only
 
+- `api_url` (String) The api url of the Vcs provider
+- `client_id` (String) The client id of the Vcs provider
 - `description` (String) Vcs description information
+- `endpoint` (String) The endpoint of the Vcs provider
 - `id` (String) Vcs Id
+- `status` (String) The status of the Vcs provider

--- a/internal/provider/vcs_data_source.go
+++ b/internal/provider/vcs_data_source.go
@@ -100,6 +100,22 @@ func (d *VcsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, re
 				Computed:    true,
 				Description: "Vcs description information",
 			},
+			"client_id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The client id of the Vcs provider",
+			},
+			"endpoint": schema.StringAttribute{
+				Computed:    true,
+				Description: "The endpoint of the Vcs provider",
+			},
+			"api_url": schema.StringAttribute{
+				Computed:    true,
+				Description: "The api url of the Vcs provider",
+			},
+			"status": schema.StringAttribute{
+				Computed:    true,
+				Description: "The status of the Vcs provider",
+			},
 		},
 	}
 }


### PR DESCRIPTION
The `terrakube_vcs` data source was updated to include more attributes in previous commit, but the schema was left out stupidly. This change addresses it.