### PR TITLE
Fixes for the Team Resource

### DIFF
--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -73,6 +73,9 @@ func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Team name",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"manage_state": schema.BoolAttribute{
 				Optional:    true,

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -373,7 +373,7 @@ func (r *TeamResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	plan.ID = types.StringValue(state.ID.ValueString())
-	plan.Name = types.StringValue(state.Name.ValueString())
+	plan.Name = types.StringValue(team.Name)
 	plan.ManageState = types.BoolValue(team.ManageState)
 	plan.ManageWorkspace = types.BoolValue(team.ManageWorkspace)
 	plan.ManageModule = types.BoolValue(team.ManageModule)

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -271,6 +271,7 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
+	state.Name = types.StringValue(team.Name)
 	state.ManageState = types.BoolValue(team.ManageState)
 	state.ManageWorkspace = types.BoolValue(team.ManageWorkspace)
 	state.ManageModule = types.BoolValue(team.ManageModule)


### PR DESCRIPTION
Proposed fixes for #92:

* [Apply the team's name to the refreshed State during `Read()`](https://github.com/AzBuilder/terraform-provider-terrakube/commit/b842f392c01b77a4c108b8660f99f45d338579bf)
* [Use the Plan's team name and not the State's during `Update()`](https://github.com/AzBuilder/terraform-provider-terrakube/commit/a4bc965419e67ec0238a01917324743fbbdb28db)

Additional related Enhancement:

* [Force a resource replacement if the Team Name changes](https://github.com/AzBuilder/terraform-provider-terrakube/commit/9cc8a777c36592c77f320473851c4b6740acc3e7)
  * Using the UI as a source of truth here (which might be mistaken, so let me know if it is), it's not intended/expected for a team's name to change once it's created. This seems supported by the original behavior of pulling the name from State during Updates. So if the expected way to rename a team is to delete and create a new one, this change is, to my knowledge, the "Terraform correct" way of expressing it.

# Caveat

I don't have an effective way to test this at the moment and I don't have much functional experience with writing Terraform providers, so if something looks like a mistake, it probably is.
