### PR TITLE
bugfix: Better HTTP error handling in organization data source

### DIFF
--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -120,12 +120,17 @@ func (d *OrganizationDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	resOrg, err := d.client.Do(reqOrg)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing organization datasource request, response status: %s, response body: %s, error: %s", resOrg.Status, resOrg.Body, err))
+		resp.Diagnostics.AddError("Request errored", fmt.Sprintf("error: %v", err))
+		return
 	}
-
 	body, err := io.ReadAll(resOrg.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading organization response, response status: %s, response body: %s, error: %s", resOrg.Status, resOrg.Body, err))
+		resp.Diagnostics.AddError("Error reading body", fmt.Sprintf("status: %v, error: %v", resOrg.Status, err))
+		return
+	}
+	if resOrg.StatusCode >= 400 {
+		resp.Diagnostics.AddError("Request failed", fmt.Sprintf("status: %v, body: %v", resOrg.Status, string(body)))
+		return
 	}
 
 	var orgs []interface{}


### PR DESCRIPTION
Currently, many forms of misconfiguration result in nil pointer derefs. Ideally, all HTTP client interaction should be centralized and look something like this, but that is a very invasive change that should wait until we have good test coverage in place. However, the organization data source is very likely to be the first HTTP request made from a configuration, so we fix that to provide proper error messages to the user. Before an invalid URL error would say:
```
╷
│ Error: Plugin did not respond
│
│ The plugin encountered an error, and failed to respond to the plugin6.(*GRPCProvider).ReadDataSource call. The
│ plugin logs may contain more details.

Stack trace from the terraform-provider-terrakube plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x829796]

goroutine 29 [running]:
terraform-provider-terrakube/internal/provider.(*OrganizationDataSource).Read(0xc000559da0, {0xe260e8, 0xc000559d40}, {{{{0xe2b1d0, 0xc000608570}, {0xbd5540, 0xc0006084e0}}, {0xe2d0b0, 0xc0003920c0}}, {{{0x0, ...}, ...}, ...}, ...}, ...)
        /home/andqvi/projects/external/terraform-provider-terrakube/internal/provider/organization_data_source.go:123 +0x456
```
After this change, we get
```
╷
│ Error: Request errored
│
│   with data.terrakube_organization.this,
│   on main.tf line 16, in data "terrakube_organization" "this":
│   16: data "terrakube_organization" "this" {
│
│ error: Get "https://terrakube-api.localtest.me:1234/api/v1/organization?filter[organization]=name==bittrance":
│ dial tcp [::1]:1234: connect: connection refused
```