### PR TITLE
feat: add validation step for resources that handles 404 status codes

### DIFF
--- a/internal/provider/collection_item_resource.go
+++ b/internal/provider/collection_item_resource.go
@@ -232,6 +232,12 @@ func (r *CollectionItemResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	if collectionItemResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Collection item not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(collectionItemResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading collection item resource response")

--- a/internal/provider/collection_reference_resource.go
+++ b/internal/provider/collection_reference_resource.go
@@ -196,6 +196,12 @@ func (r *CollectionReferenceResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
+	if collectionReferenceResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Collection reference not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(collectionReferenceResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading collection item resource response")

--- a/internal/provider/module_resource.go
+++ b/internal/provider/module_resource.go
@@ -256,6 +256,12 @@ func (r *ModuleResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
+	if moduleResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Module not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(moduleResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading module resource response")

--- a/internal/provider/organization_collection_resource.go
+++ b/internal/provider/organization_collection_resource.go
@@ -203,6 +203,12 @@ func (r *CollectionResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	if collectionResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Collection not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(collectionResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading collection resource response")

--- a/internal/provider/organization_resource.go
+++ b/internal/provider/organization_resource.go
@@ -202,6 +202,12 @@ func (r *OrganizationResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if organizationResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Organization not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(organizationResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading organization resource response")

--- a/internal/provider/organization_tag_resource.go
+++ b/internal/provider/organization_tag_resource.go
@@ -182,6 +182,12 @@ func (r *OrganizationTagResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	if organizationTagResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Organization tag not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(organizationTagResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Error reading organization tag resource response, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))

--- a/internal/provider/organization_template_resource.go
+++ b/internal/provider/organization_template_resource.go
@@ -211,6 +211,12 @@ func (r *OrganizationTemplateResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 
+	if organizationTemplateResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Organization template not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(organizationTemplateResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Error reading organization template resource response, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))

--- a/internal/provider/organization_variable_resource.go
+++ b/internal/provider/organization_variable_resource.go
@@ -225,6 +225,12 @@ func (r *OrganizationVariableResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 
+	if organizationVariableResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Organization variable not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(organizationVariableResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading organization variable resource response")

--- a/internal/provider/ssh_resource.go
+++ b/internal/provider/ssh_resource.go
@@ -207,6 +207,12 @@ func (r *SshResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
+	if sshResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "SSH key not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(sshResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading ssh key resource response")

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -258,6 +258,12 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
+	if teamResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Team not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(teamResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading team resource response")

--- a/internal/provider/team_token_resource.go
+++ b/internal/provider/team_token_resource.go
@@ -241,6 +241,7 @@ func (r *TeamTokenResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 	tflog.Info(ctx, "Response status", map[string]any{"responseStatus": teamTokenResponse.Status})
 
+	found := false
 	for _, teamToken := range *teamTokens {
 		if teamToken.ID != state.ID.ValueString() {
 			continue
@@ -251,7 +252,14 @@ func (r *TeamTokenResource) Read(ctx context.Context, req resource.ReadRequest, 
 		state.Hours = types.Int32Value(teamToken.Hours)
 		state.Minutes = types.Int32Value(teamToken.Minutes)
 		state.Group = types.StringValue(teamToken.Group)
+		found = true
 		break
+	}
+
+	if !found {
+		tflog.Warn(ctx, "Team token not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	// Set refreshed state

--- a/internal/provider/vcs_resource.go
+++ b/internal/provider/vcs_resource.go
@@ -301,6 +301,12 @@ func (r *VcsResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		return
 	}
 
+	if vcsResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "VCS not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(vcsResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Error reading organization variable resource response, error: %s, response status: %s", err, vcsResponse.Status))

--- a/internal/provider/workspace_access_resource.go
+++ b/internal/provider/workspace_access_resource.go
@@ -216,6 +216,12 @@ func (r *WorkspaceAccessResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	if workspaceAccessResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Workspace access not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(workspaceAccessResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading workspace access resource response")

--- a/internal/provider/workspace_cli_resource.go
+++ b/internal/provider/workspace_cli_resource.go
@@ -216,6 +216,12 @@ func (r *WorkspaceCliResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if workspaceResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Workspace CLI not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(workspaceResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading workspace cli resource response")

--- a/internal/provider/workspace_schedule_resource.go
+++ b/internal/provider/workspace_schedule_resource.go
@@ -191,6 +191,12 @@ func (r *WorkspaceScheduleResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
+	if workspaceScheduleResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Workspace schedule not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(workspaceScheduleResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading workspace schedule resource response")

--- a/internal/provider/workspace_tag_resource.go
+++ b/internal/provider/workspace_tag_resource.go
@@ -190,6 +190,12 @@ func (r *WorkspaceTagResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if workspaceTagResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Workspace tag not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(workspaceTagResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading workspace tag resource response")

--- a/internal/provider/workspace_variable_resource.go
+++ b/internal/provider/workspace_variable_resource.go
@@ -229,6 +229,12 @@ func (r *WorkspaceVariableResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
+	if workspaceVariableResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Workspace variable not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(workspaceVariableResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, "Error reading workspace variable resource response")

--- a/internal/provider/workspace_vcs_resource.go
+++ b/internal/provider/workspace_vcs_resource.go
@@ -287,6 +287,12 @@ func (r *WorkspaceVcsResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if workspaceResponse.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Workspace VCS not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(workspaceResponse.Body)
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Error reading workspace vcs resource response, response status: %s, response body: %s, error: %s", workspaceResponse.Status, workspaceResponse.Body, err))

--- a/internal/provider/workspace_webhook_resource.go
+++ b/internal/provider/workspace_webhook_resource.go
@@ -230,6 +230,12 @@ func (r *WorkspaceWebhookResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
+	if response.StatusCode == http.StatusNotFound {
+		tflog.Warn(ctx, "Workspace webhook not found, removing from state", map[string]any{"id": state.ID.ValueString()})
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	bodyResponse, err := io.ReadAll(response.Body)
 	if err != nil {
 		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook resource response, response status %s, response body: %s, error: %s", response.Status, response.Body, err))


### PR DESCRIPTION
Fixes #114 

This PR handles 404 status codes when the state is refreshed. These can occur from a manual deletion of a resource which is not propagated to the terraform state.

Upon receiving a 404 status code when refreshing a resource, the resource is removed gracefully from the state. The apply would then recreate the resource. 