### PR TITLE
feat(webhook-event): add pr_workflow_enabled and pr_apply_enabled toggles with tests and regenerated docs

### DIFF
--- a/docs/resources/workspace_webhook_event.md
+++ b/docs/resources/workspace_webhook_event.md
@@ -24,6 +24,8 @@ Create a webhook event attached to a webhook. Defines when and how the webhook s
 - `branch` (List of String) A list of branches that trigger a run. Support regex for more complex matching.
 - `event` (String) The event type that triggers a run. Supported values: `PUSH`, `PULL_REQUEST`, `RELEASE`.
 - `path` (List of String) The file paths in regex that trigger a run.
+- `pr_apply_enabled` (Boolean) Allow the `terrakube apply` PR-comment command to apply this workspace (`PULL_REQUEST` events only). Requires `pr_workflow_enabled` to also be true. Requires a Terrakube release including this field (targeted for 2.33.0); older instances will ignore or reject it.
+- `pr_workflow_enabled` (Boolean) Post plan results as a comment on the pull/merge request (`PULL_REQUEST` events only), and accept a `terrakube plan` PR-comment command to re-run it.
 - `priority` (Number) The priority of this webhook event
 - `template_id` (String) The template id to use for the run.
 

--- a/internal/provider/workspace_webhook_event_resource.go
+++ b/internal/provider/workspace_webhook_event_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -34,13 +35,15 @@ type WorkspaceWebhookEventResource struct {
 }
 
 type WorkspaceWebhookEventResourceModel struct {
-	ID         types.String `tfsdk:"id"`
-	WebhookId  types.String `tfsdk:"webhook_id"`
-	Event      types.String `tfsdk:"event"`
-	Branch     types.List   `tfsdk:"branch"`
-	Path       types.List   `tfsdk:"path"`
-	Priority   types.Int64  `tfsdk:"priority"`
-	TemplateId types.String `tfsdk:"template_id"`
+	ID                types.String `tfsdk:"id"`
+	WebhookId         types.String `tfsdk:"webhook_id"`
+	Event             types.String `tfsdk:"event"`
+	Branch            types.List   `tfsdk:"branch"`
+	Path              types.List   `tfsdk:"path"`
+	Priority          types.Int64  `tfsdk:"priority"`
+	TemplateId        types.String `tfsdk:"template_id"`
+	PrWorkflowEnabled types.Bool   `tfsdk:"pr_workflow_enabled"`
+	PrApplyEnabled    types.Bool   `tfsdk:"pr_apply_enabled"`
 }
 
 type webhookEventAPIResponse struct {
@@ -48,15 +51,17 @@ type webhookEventAPIResponse struct {
 		Type       string `json:"type"`
 		ID         string `json:"id"`
 		Attributes struct {
-			Branch      string `json:"branch"`
-			Path        string `json:"path"`
-			TemplateId  string `json:"templateId"`
-			Event       string `json:"event"`
-			Priority    int    `json:"priority"`
-			CreatedBy   string `json:"createdBy"`
-			CreatedDate string `json:"createdDate"`
-			UpdatedBy   string `json:"updatedBy"`
-			UpdatedDate string `json:"updatedDate"`
+			Branch            string `json:"branch"`
+			Path              string `json:"path"`
+			TemplateId        string `json:"templateId"`
+			Event             string `json:"event"`
+			Priority          int    `json:"priority"`
+			CreatedBy         string `json:"createdBy"`
+			CreatedDate       string `json:"createdDate"`
+			UpdatedBy         string `json:"updatedBy"`
+			UpdatedDate       string `json:"updatedDate"`
+			PrWorkflowEnabled bool   `json:"prWorkflowEnabled"`
+			PrApplyEnabled    bool   `json:"prApplyEnabled"`
 		} `json:"attributes"`
 		Relationships struct {
 			Webhook struct {
@@ -150,6 +155,18 @@ func (r *WorkspaceWebhookEventResource) Schema(ctx context.Context, req resource
 				Validators: []validator.String{
 					stringvalidator.OneOf("PUSH", "PULL_REQUEST", "RELEASE"),
 				},
+			},
+			"pr_workflow_enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "Post plan results as a comment on the pull/merge request (`PULL_REQUEST` events only), and accept a `terrakube plan` PR-comment command to re-run it.",
+			},
+			"pr_apply_enabled": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				Description: "Allow the `terrakube apply` PR-comment command to apply this workspace (`PULL_REQUEST` events only). Requires `pr_workflow_enabled` to also be true. Requires a Terrakube release including this field (targeted for 2.33.0); older instances will ignore or reject it.",
 			},
 		},
 	}
@@ -259,11 +276,13 @@ func (r *WorkspaceWebhookEventResource) Create(ctx context.Context, req resource
 					"type": "webhook_event",
 					"id":   eventID,
 					"attributes": map[string]interface{}{
-						"priority":   plan.Priority.ValueInt64(),
-						"event":      plan.Event.ValueString(),
-						"branch":     strings.Join(branchList, ","),
-						"path":       strings.Join(pathList, ","),
-						"templateId": plan.TemplateId.ValueString(),
+						"priority":          plan.Priority.ValueInt64(),
+						"event":             plan.Event.ValueString(),
+						"branch":            strings.Join(branchList, ","),
+						"path":              strings.Join(pathList, ","),
+						"templateId":        plan.TemplateId.ValueString(),
+						"prWorkflowEnabled": plan.PrWorkflowEnabled.ValueBool(),
+						"prApplyEnabled":    plan.PrApplyEnabled.ValueBool(),
 					},
 				},
 			},
@@ -828,11 +847,13 @@ func (r *WorkspaceWebhookEventResource) Update(ctx context.Context, req resource
 					"type": "webhook_event",
 					"id":   state.ID.ValueString(),
 					"attributes": map[string]interface{}{
-						"priority":   plan.Priority.ValueInt64(),
-						"event":      plan.Event.ValueString(),
-						"branch":     strings.Join(branchList, ","),
-						"path":       strings.Join(pathList, ","),
-						"templateId": plan.TemplateId.ValueString(),
+						"priority":          plan.Priority.ValueInt64(),
+						"event":             plan.Event.ValueString(),
+						"branch":            strings.Join(branchList, ","),
+						"path":              strings.Join(pathList, ","),
+						"templateId":        plan.TemplateId.ValueString(),
+						"prWorkflowEnabled": plan.PrWorkflowEnabled.ValueBool(),
+						"prApplyEnabled":    plan.PrApplyEnabled.ValueBool(),
 					},
 				},
 			},
@@ -973,15 +994,17 @@ func (r *WorkspaceWebhookEventResource) Update(ctx context.Context, req resource
 		Type       string `json:"type"`
 		ID         string `json:"id"`
 		Attributes struct {
-			Branch      string `json:"branch"`
-			Path        string `json:"path"`
-			TemplateId  string `json:"templateId"`
-			Event       string `json:"event"`
-			Priority    int    `json:"priority"`
-			CreatedBy   string `json:"createdBy"`
-			CreatedDate string `json:"createdDate"`
-			UpdatedBy   string `json:"updatedBy"`
-			UpdatedDate string `json:"updatedDate"`
+			Branch            string `json:"branch"`
+			Path              string `json:"path"`
+			TemplateId        string `json:"templateId"`
+			Event             string `json:"event"`
+			Priority          int    `json:"priority"`
+			CreatedBy         string `json:"createdBy"`
+			CreatedDate       string `json:"createdDate"`
+			UpdatedBy         string `json:"updatedBy"`
+			UpdatedDate       string `json:"updatedDate"`
+			PrWorkflowEnabled bool   `json:"prWorkflowEnabled"`
+			PrApplyEnabled    bool   `json:"prApplyEnabled"`
 		} `json:"attributes"`
 		Relationships struct {
 			Webhook struct {
@@ -1011,6 +1034,8 @@ func (r *WorkspaceWebhookEventResource) Update(ctx context.Context, req resource
 	plan.TemplateId = types.StringValue(foundEvent.Attributes.TemplateId)
 	plan.Event = types.StringValue(foundEvent.Attributes.Event)
 	plan.Priority = types.Int64Value(int64(foundEvent.Attributes.Priority))
+	plan.PrWorkflowEnabled = types.BoolValue(foundEvent.Attributes.PrWorkflowEnabled)
+	plan.PrApplyEnabled = types.BoolValue(foundEvent.Attributes.PrApplyEnabled)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/internal/provider/workspace_webhook_event_resource_test.go
+++ b/internal/provider/workspace_webhook_event_resource_test.go
@@ -1,0 +1,265 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// webhookEventSchemaAndType returns the resource's schema along with the
+// tftypes.Object type it maps to, so tests can build raw plan/state values
+// without hand-maintaining a duplicate of the attribute list.
+func webhookEventSchemaAndType(t *testing.T, ctx context.Context) (schema.Schema, tftypes.Object) {
+	t.Helper()
+
+	r := &WorkspaceWebhookEventResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected schema type to be a tftypes.Object")
+	}
+
+	return schemaResp.Schema, objType
+}
+
+// buildObjectValue fills every attribute of objType with a null value, then
+// overrides the ones provided. This keeps each test focused on the
+// attributes it actually cares about.
+func buildObjectValue(objType tftypes.Object, overrides map[string]tftypes.Value) tftypes.Value {
+	values := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if v, ok := overrides[name]; ok {
+			values[name] = v
+		} else {
+			values[name] = tftypes.NewValue(attrType, nil)
+		}
+	}
+	return tftypes.NewValue(objType, values)
+}
+
+func TestWorkspaceWebhookEventResource_Schema_PrToggles(t *testing.T) {
+	ctx := context.Background()
+	s, _ := webhookEventSchemaAndType(t, ctx)
+
+	for _, name := range []string{"pr_workflow_enabled", "pr_apply_enabled"} {
+		attr, ok := s.Attributes[name]
+		if !ok {
+			t.Fatalf("expected schema to define attribute %q", name)
+		}
+
+		boolAttr, ok := attr.(schema.BoolAttribute)
+		if !ok {
+			t.Fatalf("expected %q to be a BoolAttribute, got %T", name, attr)
+		}
+
+		if !boolAttr.Optional {
+			t.Errorf("%q: expected Optional to be true", name)
+		}
+		if !boolAttr.Computed {
+			t.Errorf("%q: expected Computed to be true", name)
+		}
+		if boolAttr.Default == nil {
+			t.Fatalf("%q: expected a Default to be set", name)
+		}
+
+		var defResp defaults.BoolResponse
+		boolAttr.Default.DefaultBool(ctx, defaults.BoolRequest{}, &defResp)
+		if defResp.PlanValue.ValueBool() {
+			t.Errorf("%q: expected default value false, got %v", name, defResp.PlanValue)
+		}
+	}
+}
+
+func TestWorkspaceWebhookEventResource_Create_SendsPrToggles(t *testing.T) {
+	ctx := context.Background()
+	s, objType := webhookEventSchemaAndType(t, ctx)
+
+	const webhookID = "wh-create-1"
+
+	var capturedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/webhook/"+webhookID, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data":{"type":"webhook","id":%q,"attributes":{"name":"wh"},`+
+			`"relationships":{"organization":{"data":{"type":"organization","id":"org-1"}},`+
+			`"workspace":{"data":{"type":"workspace","id":"ws-1"}},"events":{"data":[]}}}}`, webhookID)
+	})
+	mux.HandleFunc("/api/v1/operations", func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		capturedBody = body
+		fmt.Fprint(w, `{"atomic:results":[{"data":{"type":"webhook_event","id":"event-created-1"}}]}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceWebhookEventResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	planValue := buildObjectValue(objType, map[string]tftypes.Value{
+		"webhook_id":          tftypes.NewValue(tftypes.String, webhookID),
+		"event":               tftypes.NewValue(tftypes.String, "PULL_REQUEST"),
+		"priority":            tftypes.NewValue(tftypes.Number, big.NewFloat(1)),
+		"template_id":         tftypes.NewValue(tftypes.String, "tmpl-1"),
+		"pr_workflow_enabled": tftypes.NewValue(tftypes.Bool, true),
+		"pr_apply_enabled":    tftypes.NewValue(tftypes.Bool, true),
+	})
+
+	req := resource.CreateRequest{Plan: tfsdk.Plan{Schema: s, Raw: planValue}}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	if !strings.Contains(string(capturedBody), `"prWorkflowEnabled":true`) {
+		t.Errorf("expected request body to include prWorkflowEnabled:true, got: %s", capturedBody)
+	}
+	if !strings.Contains(string(capturedBody), `"prApplyEnabled":true`) {
+		t.Errorf("expected request body to include prApplyEnabled:true, got: %s", capturedBody)
+	}
+
+	var result WorkspaceWebhookEventResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if !result.PrWorkflowEnabled.ValueBool() {
+		t.Error("expected pr_workflow_enabled to remain true in state after create")
+	}
+	if !result.PrApplyEnabled.ValueBool() {
+		t.Error("expected pr_apply_enabled to remain true in state after create")
+	}
+}
+
+func TestWorkspaceWebhookEventResource_Update_RoundTripsPrToggles(t *testing.T) {
+	ctx := context.Background()
+	s, objType := webhookEventSchemaAndType(t, ctx)
+
+	const (
+		webhookID   = "wh-update-1"
+		workspaceID = "ws-update-1"
+		orgID       = "org-update-1"
+		eventID     = "event-update-1"
+	)
+
+	var capturedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/webhook/"+webhookID, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data":{"type":"webhook","id":%q,"attributes":{"name":"wh"},`+
+			`"relationships":{"organization":{"data":{"type":"organization","id":%q}},`+
+			`"workspace":{"data":{"type":"workspace","id":%q}},"events":{"data":[]}}}}`,
+			webhookID, orgID, workspaceID)
+	})
+	mux.HandleFunc("/api/v1/workspace/"+workspaceID, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data":{"type":"workspace","id":%q,"attributes":{"name":"ws"},`+
+			`"relationships":{"organization":{"data":{"type":"organization","id":%q}}}}}`,
+			workspaceID, orgID)
+	})
+	mux.HandleFunc("/api/v1/operations", func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		capturedBody = body
+		fmt.Fprintf(w, `{"atomic:results":[{"data":{"type":"webhook_event","id":%q}}]}`, eventID)
+	})
+	eventsPath := fmt.Sprintf("/api/v1/organization/%s/workspace/%s/webhook/%s/events", orgID, workspaceID, webhookID)
+	mux.HandleFunc(eventsPath, func(w http.ResponseWriter, _ *http.Request) {
+		// The server reports the toggles the way they'd look right after this
+		// update was applied: workflow on, apply still off. Using different
+		// values for the two fields catches a mix-up between them.
+		fmt.Fprintf(w, `{"data":[{"type":"webhook_event","id":%q,"attributes":{`+
+			`"branch":"main","path":"/","templateId":"tmpl-1","event":"PULL_REQUEST","priority":1,`+
+			`"createdBy":"x","createdDate":"x","updatedBy":"x","updatedDate":"x",`+
+			`"prWorkflowEnabled":true,"prApplyEnabled":false},`+
+			`"relationships":{"webhook":{"data":{"type":"webhook","id":%q}}}}]}`, eventID, webhookID)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceWebhookEventResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	base := map[string]tftypes.Value{
+		"id":          tftypes.NewValue(tftypes.String, eventID),
+		"webhook_id":  tftypes.NewValue(tftypes.String, webhookID),
+		"event":       tftypes.NewValue(tftypes.String, "PULL_REQUEST"),
+		"priority":    tftypes.NewValue(tftypes.Number, big.NewFloat(1)),
+		"template_id": tftypes.NewValue(tftypes.String, "tmpl-1"),
+	}
+
+	stateOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		stateOverrides[k] = v
+	}
+	stateOverrides["pr_workflow_enabled"] = tftypes.NewValue(tftypes.Bool, false)
+	stateOverrides["pr_apply_enabled"] = tftypes.NewValue(tftypes.Bool, false)
+
+	// Plan asks to turn pr_workflow_enabled on while leaving pr_apply_enabled
+	// off, matching the UI's gating rule that apply requires workflow first.
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		planOverrides[k] = v
+	}
+	planOverrides["pr_workflow_enabled"] = tftypes.NewValue(tftypes.Bool, true)
+	planOverrides["pr_apply_enabled"] = tftypes.NewValue(tftypes.Bool, false)
+
+	req := resource.UpdateRequest{
+		State: tfsdk.State{Schema: s, Raw: buildObjectValue(objType, stateOverrides)},
+		Plan:  tfsdk.Plan{Schema: s, Raw: buildObjectValue(objType, planOverrides)},
+	}
+	resp := &resource.UpdateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Update(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	if !strings.Contains(string(capturedBody), `"prWorkflowEnabled":true`) {
+		t.Errorf("expected request body to send the planned prWorkflowEnabled:true, got: %s", capturedBody)
+	}
+	if !strings.Contains(string(capturedBody), `"prApplyEnabled":false`) {
+		t.Errorf("expected request body to send the planned prApplyEnabled:false, got: %s", capturedBody)
+	}
+
+	var result WorkspaceWebhookEventResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if !result.PrWorkflowEnabled.ValueBool() {
+		t.Error("expected pr_workflow_enabled read back from the API to be true")
+	}
+	if result.PrApplyEnabled.ValueBool() {
+		t.Error("expected pr_apply_enabled read back from the API to be false")
+	}
+}


### PR DESCRIPTION
## Summary

Terraform-side support for the `pr_workflow_enabled` / `pr_apply_enabled` toggles on `webhook_event`, so this provider can manage the PR-comment plan/apply workflow end to end via `terrakube_workspace_webhook_event`.

Links up with [terrakube-io/terrakube#3335](https://github.com/terrakube-io/terrakube/pull/3335), which splits the old combined PR-workflow switch into separate "Post Plan on PR" (`pr_workflow_enabled`) and "Allow Apply via PR Comment" (`pr_apply_enabled`) toggles, among other PR/MR comment improvements. That PR is currently open (mergeable, CI green) but blocked on required review and targets an unreleased `2.33.0`.

- `pr_workflow_enabled` is already live on any current Terrakube release — the provider just never exposed it before this change.
- `pr_apply_enabled` is the new field from #3335 — it will no-op (or be rejected) against Terrakube instances older than whatever release ships that PR. Revisit once #3335 merges and ships.

## What changes

- `terrakube_workspace_webhook_event` gains two new attributes: `pr_workflow_enabled` and `pr_apply_enabled` (`Optional`, `Computed`, default `false`).
- Both are threaded through `Create`/`Update`'s atomic-operation payloads (`prWorkflowEnabled` / `prApplyEnabled`) and parsed back out of the API response in `Update`.
- Docs regenerated via `tfplugindocs` to document the two new attributes on `docs/resources/workspace_webhook_event.md`.

## Tests

- `TestWorkspaceWebhookEventResource_Schema_PrToggles` — both attributes are `Optional`+`Computed` with a `false` default.
- `TestWorkspaceWebhookEventResource_Create_SendsPrToggles` — mocked HTTP server asserts `Create()`'s outgoing atomic-operation JSON carries `prWorkflowEnabled`/`prApplyEnabled`.
- `TestWorkspaceWebhookEventResource_Update_RoundTripsPrToggles` — mocks the full `Update()` request chain (webhook lookup → workspace lookup → atomic update → events re-fetch) with contrasting `true`/`false` values on the two fields, verifying they're read back correctly and not swapped.
- `go build`, `go vet`, `gofmt -l`, and `go test ./...` all pass.