### PR TITLE
fix(collection-reference): guard nil workspace/collection relationships in Create/Read/Update

### DIFF
--- a/internal/provider/collection_reference_resource.go
+++ b/internal/provider/collection_reference_resource.go
@@ -164,8 +164,16 @@ func (r *CollectionReferenceResource) Create(ctx context.Context, req resource.C
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
-	plan.CollectionId = types.StringValue(collectionReference.Collection.ID)
-	plan.WorkspaceId = types.StringValue(collectionReference.Workspace.ID)
+	if collectionReference.Collection != nil {
+		plan.CollectionId = types.StringValue(collectionReference.Collection.ID)
+	} else {
+		tflog.Warn(ctx, "Collection reference response missing collection relationship data, keeping planned value")
+	}
+	if collectionReference.Workspace != nil {
+		plan.WorkspaceId = types.StringValue(collectionReference.Workspace.ID)
+	} else {
+		tflog.Warn(ctx, "Collection reference response missing workspace relationship data, keeping planned value")
+	}
 	plan.Description = types.StringPointerValue(collectionReference.Description)
 	plan.ID = types.StringValue(collectionReference.ID)
 
@@ -218,8 +226,16 @@ func (r *CollectionReferenceResource) Read(ctx context.Context, req resource.Rea
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
 
-	state.WorkspaceId = types.StringValue(collectionReference.Workspace.ID)
-	state.CollectionId = types.StringValue(collectionReference.Collection.ID)
+	if collectionReference.Workspace != nil {
+		state.WorkspaceId = types.StringValue(collectionReference.Workspace.ID)
+	} else {
+		tflog.Warn(ctx, "Collection reference response missing workspace relationship data, keeping last-known state value", map[string]any{"id": state.ID.ValueString()})
+	}
+	if collectionReference.Collection != nil {
+		state.CollectionId = types.StringValue(collectionReference.Collection.ID)
+	} else {
+		tflog.Warn(ctx, "Collection reference response missing collection relationship data, keeping last-known state value", map[string]any{"id": state.ID.ValueString()})
+	}
 	state.Description = types.StringPointerValue(collectionReference.Description)
 	state.ID = types.StringValue(collectionReference.ID)
 
@@ -310,8 +326,16 @@ func (r *CollectionReferenceResource) Update(ctx context.Context, req resource.U
 
 	plan.ID = types.StringValue(state.ID.ValueString())
 	plan.Description = types.StringPointerValue(collectionReference.Description)
-	plan.WorkspaceId = types.StringValue(collectionReference.Workspace.ID)
-	plan.CollectionId = types.StringValue(collectionReference.Collection.ID)
+	if collectionReference.Workspace != nil {
+		plan.WorkspaceId = types.StringValue(collectionReference.Workspace.ID)
+	} else {
+		tflog.Warn(ctx, "Collection reference response missing workspace relationship data, keeping planned value")
+	}
+	if collectionReference.Collection != nil {
+		plan.CollectionId = types.StringValue(collectionReference.Collection.ID)
+	} else {
+		tflog.Warn(ctx, "Collection reference response missing collection relationship data, keeping planned value")
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/internal/provider/collection_reference_resource_test.go
+++ b/internal/provider/collection_reference_resource_test.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func collectionReferenceSchemaAndType(t *testing.T, ctx context.Context) (schema.Schema, tftypes.Object) {
+	t.Helper()
+
+	r := &CollectionReferenceResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected schema type to be a tftypes.Object")
+	}
+
+	return schemaResp.Schema, objType
+}
+
+// TestCollectionReferenceResource_Read_HandlesNullWorkspaceRelationship covers
+// the drift scenario where Terrakube returns relationships.workspace.data = null
+// (e.g. the referenced workspace was deleted out of band). Reading must not
+// panic and should keep the last-known workspace_id instead of crashing.
+func TestCollectionReferenceResource_Read_HandlesNullWorkspaceRelationship(t *testing.T) {
+	ctx := context.Background()
+	s, objType := collectionReferenceSchemaAndType(t, ctx)
+
+	const (
+		refID   = "ref-1"
+		orgID   = "org-1"
+		oldWsID = "ws-old"
+		colID   = "col-1"
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/reference/"+refID, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data":{"type":"reference","id":%q,"attributes":{"description":"d"},`+
+			`"relationships":{"workspace":{"data":null},"collection":{"data":{"type":"collection","id":%q}}}}}`,
+			refID, colID)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &CollectionReferenceResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	stateValue := buildObjectValue(objType, map[string]tftypes.Value{
+		"id":              tftypes.NewValue(tftypes.String, refID),
+		"organization_id": tftypes.NewValue(tftypes.String, orgID),
+		"workspace_id":    tftypes.NewValue(tftypes.String, oldWsID),
+		"collection_id":   tftypes.NewValue(tftypes.String, colID),
+		"description":     tftypes.NewValue(tftypes.String, "d"),
+	})
+
+	req := resource.ReadRequest{State: tfsdk.State{Schema: s, Raw: stateValue}}
+	resp := &resource.ReadResponse{State: tfsdk.State{Schema: s}}
+
+	r.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	var result CollectionReferenceResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if result.WorkspaceId.ValueString() != oldWsID {
+		t.Errorf("expected workspace_id to keep last-known value %q when relationship data is null, got %q", oldWsID, result.WorkspaceId.ValueString())
+	}
+	if result.CollectionId.ValueString() != colID {
+		t.Errorf("expected collection_id to be updated to %q, got %q", colID, result.CollectionId.ValueString())
+	}
+}


### PR DESCRIPTION
## Problem

`terrakube_collection_reference`'s `Read` (and `Create`/`Update`) crashed the provider with a nil-pointer panic:

terraform-provider-terrakube/internal/provider.(*CollectionReferenceResource).Read(...)
    terraform-provider-terrakube/internal/provider/collection_reference_resource.go:221 +0xbd1

Terrakube's JSON:API response can return `relationships.workspace.data: null` (or `relationships.collection.data: null`) when the referenced workspace or collection no longer exists — e.g. it was deleted outside of Terraform. In that case `jsonapi.UnmarshalPayload` leaves `CollectionReferenceEntity.Workspace` / `.Collection` as `nil`, and the resource unconditionally dereferenced `.Workspace.ID` / `.Collection.ID`, panicking instead of handling the drift gracefully.

## Solution

Added nil checks around every place the resource reads `Workspace`/`Collection` off the API response (`Create`, `Read`, `Update`):

- If the relationship data is present, use it as before.
- If it's `null`, keep the last-known value (from state in `Read`, from plan in `Create`/`Update`) and log a `tflog.Warn` instead of crashing.

This keeps the provider resilient to this kind of drift without silently losing or fabricating an ID.

And now.... with the fix:
1. Refresh survives — `Read` keeps the last-known `workspace_id` in state instead of crashing.
2. Terraform can now build the plan, see `workspace_id` is (known after apply) because it references the not-yet-created workspace resource.
3. Apply creates the new workspace first (dependency ordering), then calls `Update` on `collection_reference` with the now-resolved real ID — `workspace_id` has no `RequiresReplace` plan modifier, so it updates in place rather than forcing a replace of the reference resource itself.
4. `Update` PATCHes with that resolved ID and re-fetches to confirm — since the new workspace exists, the response comes back non-null and state ends up correct.

## Testing

- Added `collection_reference_resource_test.go` with a regression test that spins up a mock Terrakube server returning `"workspace":{"data":null}` and asserts `Read` no longer panics and retains the previous `workspace_id`.
- Confirmed the test reproduces the original panic against the pre-fix code, and passes after the fix.
- `go build ./...`, `go vet ./...`, `go test ./internal/...` all pass.