### PR TITLE
fix(provider): project_id, error bodies, and webhook v2 provider bugs

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -204,11 +204,11 @@ type WorkspaceWebhookEntity struct {
 
 type WorkspaceWebhookV2Entity struct {
 	ID           string           `jsonapi:"primary,webhook"`
-	CreatedBy    string           `jsonapi:"attr,createdBy"`
-	CreatedDate  string           `jsonapi:"attr,createdDate"`
-	RemoteHookId string           `jsonapi:"attr,remoteHookId"`
-	UpdatedBy    string           `jsonapi:"attr,updatedBy"`
-	UpdatedDate  string           `jsonapi:"attr,updatedDate"`
+	CreatedBy    string           `jsonapi:"attr,createdBy,omitempty"`
+	CreatedDate  string           `jsonapi:"attr,createdDate,omitempty"`
+	RemoteHookId string           `jsonapi:"attr,remoteHookId,omitempty"`
+	UpdatedBy    string           `jsonapi:"attr,updatedBy,omitempty"`
+	UpdatedDate  string           `jsonapi:"attr,updatedDate,omitempty"`
 	MigratedV2   *bool            `jsonapi:"attr,migratedV2"`
 	Events       []WebhookEvent   `jsonapi:"relation,events,omitempty"`
 	Workspace    *WorkspaceEntity `jsonapi:"relation,workspace,omitempty"`

--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -138,7 +138,7 @@ func (d *OrganizationDataSource) Read(ctx context.Context, req datasource.ReadRe
 	orgs, err = jsonapi.UnmarshalManyPayload(strings.NewReader(string(body)), reflect.TypeOf(new(client.OrganizationEntity)))
 
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resOrg.Status, resOrg.Body, err))
+		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resOrg.Status, string(body), err))
 		return
 	}
 

--- a/internal/provider/organization_tag_resource.go
+++ b/internal/provider/organization_tag_resource.go
@@ -133,20 +133,20 @@ func (r *OrganizationTagResource) Create(ctx context.Context, req resource.Creat
 
 	organizationTagResponse, err := r.client.Do(organizationTagRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err := io.ReadAll(organizationTagResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading organization tag resource response, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading organization tag resource response, response status: %s, error: %s", organizationTagResponse.Status, err))
 	}
 	newOrganizationTag := &client.OrganizationTagEntity{}
 
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), newOrganizationTag)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", organizationTagResponse.Status, string(bodyResponse), err))
 		return
 	}
 
@@ -178,7 +178,7 @@ func (r *OrganizationTagResource) Read(ctx context.Context, req resource.ReadReq
 
 	organizationTagResponse, err := r.client.Do(organizationTagRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request: %s", err))
 		return
 	}
 
@@ -190,7 +190,7 @@ func (r *OrganizationTagResource) Read(ctx context.Context, req resource.ReadReq
 
 	bodyResponse, err := io.ReadAll(organizationTagResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading organization tag resource response, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading organization tag resource response, response status: %s, error: %s", organizationTagResponse.Status, err))
 	}
 	organizationTag := &client.OrganizationTagEntity{}
 
@@ -198,7 +198,7 @@ func (r *OrganizationTagResource) Read(ctx context.Context, req resource.ReadReq
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), organizationTag)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", organizationTagResponse.Status, string(bodyResponse), err))
 		return
 	}
 
@@ -249,13 +249,13 @@ func (r *OrganizationTagResource) Update(ctx context.Context, req resource.Updat
 
 	organizationTagResponse, err := r.client.Do(organizationTagRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err := io.ReadAll(organizationTagResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading organization tag resource response, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading organization tag resource response, response status: %s, error: %s", organizationTagResponse.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
@@ -270,13 +270,13 @@ func (r *OrganizationTagResource) Update(ctx context.Context, req resource.Updat
 
 	organizationTagResponse, err = r.client.Do(organizationTagRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err = io.ReadAll(organizationTagResponse.Body)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading organization tag resource response body", fmt.Sprintf("Error reading organization tag resource response body, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+		resp.Diagnostics.AddError("Error reading organization tag resource response body", fmt.Sprintf("Error reading organization tag resource response body, response status: %s, error: %s", organizationTagResponse.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
@@ -313,8 +313,13 @@ func (r *OrganizationTagResource) Delete(ctx context.Context, req resource.Delet
 	}
 
 	organizationTagResponse, err := r.client.Do(reqOrg)
-	if err != nil || organizationTagResponse.StatusCode != http.StatusNoContent {
-		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request, response status: %s, response body: %s, body: %s", organizationTagResponse.Status, organizationTagResponse.Body, err))
+	if err != nil {
+		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request: %s", err))
+		return
+	}
+	if organizationTagResponse.StatusCode != http.StatusNoContent {
+		deleteBody, _ := io.ReadAll(organizationTagResponse.Body)
+		resp.Diagnostics.AddError("Error executing organization tag resource request", fmt.Sprintf("Error executing organization tag resource request, response status: %s, response body: %s", organizationTagResponse.Status, string(deleteBody)))
 		return
 	}
 }

--- a/internal/provider/organization_template_resource.go
+++ b/internal/provider/organization_template_resource.go
@@ -154,20 +154,20 @@ func (r *OrganizationTemplateResource) Create(ctx context.Context, req resource.
 
 	organizationTemplateResponse, err := r.client.Do(organizationTemplateRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err := io.ReadAll(organizationTemplateResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading organization template resource response, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading organization template resource response, response status: %s, error: %s", organizationTemplateResponse.Status, err))
 	}
 	organizationTemplate := &client.OrganizationTemplateEntity{}
 
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), organizationTemplate)
 	tflog.Info(ctx, string(bodyResponse))
 	if err != nil {
-		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, string(bodyResponse), err))
 		return
 	}
 
@@ -207,7 +207,7 @@ func (r *OrganizationTemplateResource) Read(ctx context.Context, req resource.Re
 
 	organizationTemplateResponse, err := r.client.Do(organizationTemplateRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request: %s", err))
 		return
 	}
 
@@ -219,7 +219,7 @@ func (r *OrganizationTemplateResource) Read(ctx context.Context, req resource.Re
 
 	bodyResponse, err := io.ReadAll(organizationTemplateResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading organization template resource response, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading organization template resource response, response status: %s, error: %s", organizationTemplateResponse.Status, err))
 	}
 	organizationTemplate := &client.OrganizationTemplateEntity{}
 
@@ -292,13 +292,13 @@ func (r *OrganizationTemplateResource) Update(ctx context.Context, req resource.
 
 	organizationTemplateResponse, err := r.client.Do(organizationTemplateRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err := io.ReadAll(organizationTemplateResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading organization template resource response, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading organization template resource response, response status: %s, error: %s", organizationTemplateResponse.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
@@ -313,13 +313,13 @@ func (r *OrganizationTemplateResource) Update(ctx context.Context, req resource.
 
 	organizationTemplateResponse, err = r.client.Do(organizationTemplateRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err = io.ReadAll(organizationTemplateResponse.Body)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading organization template resource response body", fmt.Sprintf("Error reading organization template resource response body, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+		resp.Diagnostics.AddError("Error reading organization template resource response body", fmt.Sprintf("Error reading organization template resource response body, response status: %s, error: %s", organizationTemplateResponse.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
@@ -364,8 +364,13 @@ func (r *OrganizationTemplateResource) Delete(ctx context.Context, req resource.
 	}
 
 	organizationTemplateResponse, err := r.client.Do(organizationTemplateRequest)
-	if err != nil || organizationTemplateResponse.StatusCode != http.StatusNoContent {
-		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request, response status: %s, response body: %s, error: %s", organizationTemplateResponse.Status, organizationTemplateResponse.Body, err))
+	if err != nil {
+		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request: %s", err))
+		return
+	}
+	if organizationTemplateResponse.StatusCode != http.StatusNoContent {
+		deleteBody, _ := io.ReadAll(organizationTemplateResponse.Body)
+		resp.Diagnostics.AddError("Error executing organization template resource request", fmt.Sprintf("Error executing organization template resource request, response status: %s, response body: %s", organizationTemplateResponse.Status, string(deleteBody)))
 		return
 	}
 }

--- a/internal/provider/output_data_source.go
+++ b/internal/provider/output_data_source.go
@@ -163,12 +163,13 @@ func (d *OutputDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	resFile, err := d.client.Do(reqFile)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Output datasource request part 4, response status: %s, response body: %s, error: %s", resFile.Status, resFile.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error executing Output datasource request part 4: %s", err))
+		return
 	}
 
 	bodyFile, err := io.ReadAll(resFile.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading Output response part 4, response status: %s, response body: %s, error: %s", resFile.Status, resFile.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading Output response part 4, response status: %s, error: %s", resFile.Status, err))
 	}
 
 	var result map[string]interface{}
@@ -439,12 +440,13 @@ func (d *OutputDataSource) ReadDataFromApi(url string, ctx context.Context, resp
 
 	resApi, err := d.client.Do(regApi)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Output datasource request, response status: %s, response body: %s, error: %s", resApi.Status, resApi.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error executing Output datasource request: %s", err))
+		return
 	}
 
 	body, err := io.ReadAll(resApi.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading Output response, response status: %s, response body: %s, error: %s", resApi.Status, resApi.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading Output response, response status: %s, error: %s", resApi.Status, err))
 	}
 
 	tflog.Info(ctx, string(body))
@@ -452,7 +454,7 @@ func (d *OutputDataSource) ReadDataFromApi(url string, ctx context.Context, resp
 	data, err = jsonapi.UnmarshalManyPayload(strings.NewReader(string(body)), reflect.TypeOf(structType))
 
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resApi.Status, resApi.Body, err))
+		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resApi.Status, string(body), err))
 		return
 	}
 

--- a/internal/provider/project_data_source.go
+++ b/internal/provider/project_data_source.go
@@ -153,12 +153,13 @@ func (d *ProjectDataSource) ReadDataFromApi(url string, ctx context.Context, res
 
 	resApi, err := d.client.Do(regApi)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Project datasource request, response status: %s, response body: %s, error: %s", resApi.Status, resApi.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error executing Project datasource request: %s", err))
+		return
 	}
 
 	body, err := io.ReadAll(resApi.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading Project response, response status: %s, response body: %s, error: %s", resApi.Status, resApi.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading Project response, response status: %s, error: %s", resApi.Status, err))
 	}
 
 	tflog.Info(ctx, string(body))
@@ -166,7 +167,7 @@ func (d *ProjectDataSource) ReadDataFromApi(url string, ctx context.Context, res
 	data, err = jsonapi.UnmarshalManyPayload(strings.NewReader(string(body)), reflect.TypeOf(structType))
 
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resApi.Status, resApi.Body, err))
+		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resApi.Status, string(body), err))
 		return
 	}
 

--- a/internal/provider/team_data_source.go
+++ b/internal/provider/team_data_source.go
@@ -188,12 +188,13 @@ func (d *TeamDataSource) ReadDataFromApi(url string, ctx context.Context, resp *
 
 	resApi, err := d.client.Do(regApi)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Team datasource request, response status: %s, response body: %s, error: %s", resApi.Status, resApi.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error executing Team datasource request: %s", err))
+		return
 	}
 
 	body, err := io.ReadAll(resApi.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading Team response, response status: %s, response body: %s, error: %s", resApi.Status, resApi.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading Team response, response status: %s, error: %s", resApi.Status, err))
 	}
 
 	tflog.Info(ctx, string(body))
@@ -201,7 +202,7 @@ func (d *TeamDataSource) ReadDataFromApi(url string, ctx context.Context, resp *
 	data, err = jsonapi.UnmarshalManyPayload(strings.NewReader(string(body)), reflect.TypeOf(structType))
 
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resApi.Status, resApi.Body, err))
+		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resApi.Status, string(body), err))
 		return
 	}
 

--- a/internal/provider/team_token_resource.go
+++ b/internal/provider/team_token_resource.go
@@ -294,8 +294,13 @@ func (r *TeamTokenResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	resToken, err := r.client.Do(reqToken)
-	if err != nil || resToken.StatusCode != http.StatusAccepted {
-		resp.Diagnostics.AddError("Error deleting team token", fmt.Sprintf("Error deleting team token, error: %s, response status: %s, response body: %s", err, resToken.Status, resToken.Body))
+	if err != nil {
+		resp.Diagnostics.AddError("Error deleting team token", fmt.Sprintf("Error deleting team token: %s", err))
+		return
+	}
+	if resToken.StatusCode != http.StatusAccepted {
+		deleteBody, _ := io.ReadAll(resToken.Body)
+		resp.Diagnostics.AddError("Error deleting team token", fmt.Sprintf("Error deleting team token, response status: %s, response body: %s", resToken.Status, string(deleteBody)))
 		return
 	}
 }

--- a/internal/provider/vcs_resource.go
+++ b/internal/provider/vcs_resource.go
@@ -234,7 +234,7 @@ func (r *VcsResource) Create(ctx context.Context, req resource.CreateRequest, re
 
 	vcsResponse, err := r.client.Do(vcsRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request, response status %s, response body %s, error: %s", vcsResponse.Status, vcsResponse.Request.Body, err))
+		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request: %s", err))
 		return
 	}
 
@@ -297,7 +297,7 @@ func (r *VcsResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 
 	vcsResponse, err := r.client.Do(vcsRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request, response status %s, response body %s, error: %s", vcsResponse.Status, vcsResponse.Request.Body, err))
+		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request: %s", err))
 		return
 	}
 
@@ -391,7 +391,7 @@ func (r *VcsResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	vcsResponse, err := r.client.Do(vcsRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request, response status %s, response body %s, error: %s", vcsResponse.Status, vcsResponse.Request.Body, err))
+		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request: %s", err))
 		return
 	}
 
@@ -412,7 +412,7 @@ func (r *VcsResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	vcsResponse, err = r.client.Do(vcsRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request, response status %s, response body %s, error: %s", vcsResponse.Status, vcsResponse.Request.Body, err))
+		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request: %s", err))
 		return
 	}
 
@@ -474,8 +474,13 @@ func (r *VcsResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	}
 
 	vcsResponse, err := r.client.Do(vcsRequest)
-	if err != nil || vcsResponse.StatusCode != http.StatusNoContent {
-		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request, response status %s, response body %s, error: %s", vcsResponse.Status, vcsResponse.Request.Body, err))
+	if err != nil {
+		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request: %s", err))
+		return
+	}
+	if vcsResponse.StatusCode != http.StatusNoContent {
+		deleteBody, _ := io.ReadAll(vcsResponse.Body)
+		resp.Diagnostics.AddError("Error executing VCS resource request", fmt.Sprintf("Error executing VCS resource request, response status %s, response body %s", vcsResponse.Status, string(deleteBody)))
 		return
 	}
 }

--- a/internal/provider/workspace_cli_resource.go
+++ b/internal/provider/workspace_cli_resource.go
@@ -185,7 +185,6 @@ func (r *WorkspaceCliResource) Create(ctx context.Context, req resource.CreateRe
 	}
 	newWorkspaceCli := &client.WorkspaceEntity{}
 
-	fmt.Println(string(bodyResponse))
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), newWorkspaceCli)
 
 	if err != nil {
@@ -369,6 +368,8 @@ func (r *WorkspaceCliResource) Update(ctx context.Context, req resource.UpdateRe
 	plan.ExecutionMode = types.StringValue(workspace.ExecutionMode)
 	if workspace.Project != nil {
 		plan.ProjectId = types.StringValue(workspace.Project.ID)
+	} else {
+		plan.ProjectId = types.StringNull()
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/internal/provider/workspace_cli_resource.go
+++ b/internal/provider/workspace_cli_resource.go
@@ -153,7 +153,7 @@ func (r *WorkspaceCliResource) Create(ctx context.Context, req resource.CreateRe
 		ExecutionMode: plan.ExecutionMode.ValueString(),
 	}
 
-	if !plan.ProjectId.IsNull() {
+	if !plan.ProjectId.IsNull() && !plan.ProjectId.IsUnknown() {
 		bodyRequest.Project = &client.ProjectEntity{ID: plan.ProjectId.ValueString()}
 	}
 
@@ -203,6 +203,8 @@ func (r *WorkspaceCliResource) Create(ctx context.Context, req resource.CreateRe
 	plan.ExecutionMode = types.StringValue(newWorkspaceCli.ExecutionMode)
 	if newWorkspaceCli.Project != nil {
 		plan.ProjectId = types.StringValue(newWorkspaceCli.Project.ID)
+	} else {
+		plan.ProjectId = types.StringNull()
 	}
 
 	tflog.Info(ctx, "Workspace Cli Resource Created", map[string]any{"success": true})
@@ -297,7 +299,7 @@ func (r *WorkspaceCliResource) Update(ctx context.Context, req resource.UpdateRe
 		ID:            state.ID.ValueString(),
 	}
 
-	if !plan.ProjectId.IsNull() {
+	if !plan.ProjectId.IsNull() && !plan.ProjectId.IsUnknown() {
 		bodyRequest.Project = &client.ProjectEntity{ID: plan.ProjectId.ValueString()}
 	}
 

--- a/internal/provider/workspace_data_source.go
+++ b/internal/provider/workspace_data_source.go
@@ -170,12 +170,13 @@ func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	resOrg, err := d.client.Do(reqOrg)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Workspace datasource request, response status: %s, response body: %s, error: %s", resOrg.Status, resOrg.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error executing Workspace datasource request: %s", err))
+		return
 	}
 
 	body, err := io.ReadAll(resOrg.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading Workspace response, response status: %s, response body: %s, error: %s", resOrg.Status, resOrg.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading Workspace response, response status: %s, error: %s", resOrg.Status, err))
 	}
 
 	tflog.Info(ctx, string(body))
@@ -184,7 +185,7 @@ func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 	orgs, err = jsonapi.UnmarshalManyPayload(strings.NewReader(string(body)), reflect.TypeOf(new(client.OrganizationEntity)))
 
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resOrg.Status, resOrg.Body, err))
+		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resOrg.Status, string(body), err))
 		return
 	}
 
@@ -210,12 +211,13 @@ func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	resWS, err := d.client.Do(reqWS)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Workspace datasource request part 2, response status: %s, response body: %s, error: %s", resWS.Status, resWS.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error executing Workspace datasource request part 2: %s", err))
+		return
 	}
 
 	bodyws, errws := io.ReadAll(resWS.Body)
-	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading Workspace response part 2, response status: %s, response body: %s, error: %s", resWS.Status, resWS.Body, errws))
+	if errws != nil {
+		tflog.Error(ctx, fmt.Sprintf("Error reading Workspace response part 2, response status: %s, error: %s", resWS.Status, errws))
 	}
 
 	tflog.Info(ctx, string(bodyws))
@@ -224,7 +226,7 @@ func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 	workspaces, err = jsonapi.UnmarshalManyPayload(strings.NewReader(string(bodyws)), reflect.TypeOf(new(client.WorkspaceEntity)))
 
 	if err != nil {
-		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resWS.Status, resWS.Body, err))
+		resp.Diagnostics.AddError("Unable to unmarshal payload", fmt.Sprintf("Unable to marshal payload, response status: %s, response body: %s, error: %s", resWS.Status, string(bodyws), err))
 		return
 	}
 

--- a/internal/provider/workspace_vcs_resource.go
+++ b/internal/provider/workspace_vcs_resource.go
@@ -233,21 +233,20 @@ func (r *WorkspaceVcsResource) Create(ctx context.Context, req resource.CreateRe
 
 	workspaceVcsResponse, err := r.client.Do(workspaceVcsRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace vcs resource request", fmt.Sprintf("Error executing workspace vcs resource request, response status: %s, response body: %s, error: %s", workspaceVcsResponse.Status, workspaceVcsResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace vcs resource request", fmt.Sprintf("Error executing workspace vcs resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err := io.ReadAll(workspaceVcsResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace vcs resource response, response status: %s, response body: %s, error: %s", workspaceVcsResponse.Status, workspaceVcsResponse.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace vcs resource response, response status: %s, error: %s", workspaceVcsResponse.Status, err))
 	}
 	newWorkspaceVcs := &client.WorkspaceEntity{}
 
-	fmt.Println(string(bodyResponse))
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), newWorkspaceVcs)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", workspaceVcsResponse.Status, workspaceVcsResponse.Body, err))
+		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", workspaceVcsResponse.Status, string(bodyResponse), err))
 		return
 	}
 
@@ -302,7 +301,7 @@ func (r *WorkspaceVcsResource) Read(ctx context.Context, req resource.ReadReques
 
 	workspaceResponse, err := r.client.Do(workspaceRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace vcs resource request", fmt.Sprintf("Error executing workspace cli resource request, response status: %s, response body: %s, error: %s", workspaceResponse.Status, workspaceResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace vcs resource request", fmt.Sprintf("Error executing workspace cli resource request: %s", err))
 		return
 	}
 
@@ -314,7 +313,7 @@ func (r *WorkspaceVcsResource) Read(ctx context.Context, req resource.ReadReques
 
 	bodyResponse, err := io.ReadAll(workspaceResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace vcs resource response, response status: %s, response body: %s, error: %s", workspaceResponse.Status, workspaceResponse.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace vcs resource response, response status: %s, error: %s", workspaceResponse.Status, err))
 	}
 	workspace := &client.WorkspaceEntity{}
 
@@ -322,7 +321,7 @@ func (r *WorkspaceVcsResource) Read(ctx context.Context, req resource.ReadReques
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), workspace)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", workspaceResponse.Status, workspaceResponse.Body, err))
+		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", workspaceResponse.Status, string(bodyResponse), err))
 		return
 	}
 
@@ -411,13 +410,13 @@ func (r *WorkspaceVcsResource) Update(ctx context.Context, req resource.UpdateRe
 
 	organizationResponse, err := r.client.Do(organizationRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace vcs resource request", fmt.Sprintf("Error executing workspace vcs resource request, response status: %s, response body: %s, error: %s", organizationResponse.Status, organizationResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace vcs resource request", fmt.Sprintf("Error executing workspace vcs resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err := io.ReadAll(organizationResponse.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace vcs resource response, response status: %s, response body: %s, error: %s", organizationResponse.Status, organizationResponse.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace vcs resource response, response status: %s, error: %s", organizationResponse.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
@@ -432,13 +431,13 @@ func (r *WorkspaceVcsResource) Update(ctx context.Context, req resource.UpdateRe
 
 	organizationResponse, err = r.client.Do(organizationRequest)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace vcs resource request", fmt.Sprintf("Error executing workspace vcs resource request, response status: %s, response body: %s, error: %s", organizationResponse.Status, organizationResponse.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace vcs resource request", fmt.Sprintf("Error executing workspace vcs resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err = io.ReadAll(organizationResponse.Body)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading workspace vcs resource response body", fmt.Sprintf("Error reading workspace vcs resource response body, response status: %s, response body: %s, error: %s", organizationResponse.Status, organizationResponse.Body, err))
+		resp.Diagnostics.AddError("Error reading workspace vcs resource response body", fmt.Sprintf("Error reading workspace vcs resource response body, response status: %s, error: %s", organizationResponse.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
@@ -447,7 +446,7 @@ func (r *WorkspaceVcsResource) Update(ctx context.Context, req resource.UpdateRe
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), workspace)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", organizationResponse.Status, organizationResponse.Body, err))
+		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status: %s, response body: %s, error: %s", organizationResponse.Status, string(bodyResponse), err))
 		return
 	}
 
@@ -467,6 +466,8 @@ func (r *WorkspaceVcsResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 	if workspace.Project != nil {
 		plan.ProjectId = types.StringValue(workspace.Project.ID)
+	} else {
+		plan.ProjectId = types.StringNull()
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -533,8 +534,13 @@ func (r *WorkspaceVcsResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	workspaceVcsResponse, err := r.client.Do(workspaceVcsRequest)
-	if err != nil || workspaceVcsResponse.StatusCode != http.StatusNoContent {
-		resp.Diagnostics.AddError("Error executing vcs resource request", fmt.Sprintf("Error executing vcs resource request, response status: %s, response body: %s, error: %s", workspaceVcsResponse.Status, workspaceVcsResponse.Body, err))
+	if err != nil {
+		resp.Diagnostics.AddError("Error executing vcs resource request", fmt.Sprintf("Error executing vcs resource request: %s", err))
+		return
+	}
+	if workspaceVcsResponse.StatusCode != http.StatusNoContent {
+		deleteBody, _ := io.ReadAll(workspaceVcsResponse.Body)
+		resp.Diagnostics.AddError("Error executing vcs resource request", fmt.Sprintf("Error executing vcs resource request, response status: %s, response body: %s", workspaceVcsResponse.Status, string(deleteBody)))
 		return
 	}
 

--- a/internal/provider/workspace_vcs_resource.go
+++ b/internal/provider/workspace_vcs_resource.go
@@ -211,7 +211,7 @@ func (r *WorkspaceVcsResource) Create(ctx context.Context, req resource.CreateRe
 		bodyRequest.Vcs = &client.VcsEntity{ID: plan.VcsId.ValueString()}
 	}
 
-	if !plan.ProjectId.IsNull() {
+	if !plan.ProjectId.IsNull() && !plan.ProjectId.IsUnknown() {
 		bodyRequest.Project = &client.ProjectEntity{ID: plan.ProjectId.ValueString()}
 	}
 
@@ -267,6 +267,8 @@ func (r *WorkspaceVcsResource) Create(ctx context.Context, req resource.CreateRe
 
 	if newWorkspaceVcs.Project != nil {
 		plan.ProjectId = types.StringValue(newWorkspaceVcs.Project.ID)
+	} else {
+		plan.ProjectId = types.StringNull()
 	}
 
 	if !plan.VcsId.IsNull() {
@@ -387,7 +389,7 @@ func (r *WorkspaceVcsResource) Update(ctx context.Context, req resource.UpdateRe
 		bodyRequest.Vcs = &client.VcsEntity{ID: plan.VcsId.ValueString()}
 	}
 
-	if !plan.ProjectId.IsNull() {
+	if !plan.ProjectId.IsNull() && !plan.ProjectId.IsUnknown() {
 		bodyRequest.Project = &client.ProjectEntity{ID: plan.ProjectId.ValueString()}
 	}
 

--- a/internal/provider/workspace_vcs_resource_test.go
+++ b/internal/provider/workspace_vcs_resource_test.go
@@ -1,0 +1,116 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// workspaceVcsSchemaAndType returns the resource's schema along with the
+// tftypes.Object type it maps to, so tests can build raw plan/state values
+// without hand-maintaining a duplicate of the attribute list.
+func workspaceVcsSchemaAndType(t *testing.T, ctx context.Context) (schema.Schema, tftypes.Object) {
+	t.Helper()
+
+	r := &WorkspaceVcsResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected schema type to be a tftypes.Object")
+	}
+
+	return schemaResp.Schema, objType
+}
+
+// TestWorkspaceVcsResource_Create_OmitsProjectRelationshipWhenProjectIdUnset
+// covers a real bug: project_id is Optional+Computed with no Default, so
+// when it's left out of the config, Terraform's plan leaves it *unknown*
+// (not null) during Create. The old guard only checked IsNull(), so it sent
+// a "project" relationship with an empty id, which the API rejected with a
+// 404 that the provider then couldn't unmarshal.
+func TestWorkspaceVcsResource_Create_OmitsProjectRelationshipWhenProjectIdUnset(t *testing.T) {
+	ctx := context.Background()
+	s, objType := workspaceVcsSchemaAndType(t, ctx)
+
+	const orgID = "org-1"
+
+	var capturedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/organization/"+orgID+"/workspace", func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		capturedBody = body
+		fmt.Fprint(w, `{"data":{"type":"workspace","id":"ws-created-1","attributes":{`+
+			`"name":"my-workspace","description":null,"source":"https://example.com/repo.git",`+
+			`"branch":"main","folder":"/","defaultTemplate":"tmpl-1","iacType":"terraform",`+
+			`"terraformVersion":"1.12.0","executionMode":"remote","allowRemoteApply":false},`+
+			`"relationships":{"project":{"data":null}}}}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceVcsResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	planValue := buildObjectValue(objType, map[string]tftypes.Value{
+		"organization_id":    tftypes.NewValue(tftypes.String, orgID),
+		"name":               tftypes.NewValue(tftypes.String, "my-workspace"),
+		"repository":         tftypes.NewValue(tftypes.String, "https://example.com/repo.git"),
+		"template_id":        tftypes.NewValue(tftypes.String, "tmpl-1"),
+		"iac_version":        tftypes.NewValue(tftypes.String, "1.12.0"),
+		"branch":             tftypes.NewValue(tftypes.String, "main"),
+		"folder":             tftypes.NewValue(tftypes.String, "/"),
+		"iac_type":           tftypes.NewValue(tftypes.String, "terraform"),
+		"execution_mode":     tftypes.NewValue(tftypes.String, "remote"),
+		"allow_remote_apply": tftypes.NewValue(tftypes.Bool, false),
+		// project_id is intentionally left unknown, matching what Terraform
+		// actually produces for an Optional+Computed attribute that's absent
+		// from config during Create (never null).
+		"project_id": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	})
+
+	req := resource.CreateRequest{Plan: tfsdk.Plan{Schema: s, Raw: planValue}}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	if strings.Contains(string(capturedBody), `"project"`) {
+		t.Errorf("expected request body to omit the project relationship when project_id is unset, got: %s", capturedBody)
+	}
+
+	var result WorkspaceVcsResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if result.ProjectId.IsUnknown() {
+		t.Error("expected project_id to be resolved to null after create, but it is still unknown (Terraform's protocol rejects unknown values after apply)")
+	}
+	if !result.ProjectId.IsNull() {
+		t.Errorf("expected project_id to be null after create since the API returned no project, got: %v", result.ProjectId)
+	}
+}

--- a/internal/provider/workspace_vcs_resource_test.go
+++ b/internal/provider/workspace_vcs_resource_test.go
@@ -114,3 +114,88 @@ func TestWorkspaceVcsResource_Create_OmitsProjectRelationshipWhenProjectIdUnset(
 		t.Errorf("expected project_id to be null after create since the API returned no project, got: %v", result.ProjectId)
 	}
 }
+
+// TestWorkspaceVcsResource_Update_ResolvesProjectIdToNullWhenApiReturnsNoProject
+// covers the same class of bug as the Create test above, but in Update: if
+// the API reports no project relationship, ProjectId must be explicitly set
+// to null rather than left holding a stale prior value (or unknown), since
+// Terraform's protocol rejects unknown values after apply.
+func TestWorkspaceVcsResource_Update_ResolvesProjectIdToNullWhenApiReturnsNoProject(t *testing.T) {
+	ctx := context.Background()
+	s, objType := workspaceVcsSchemaAndType(t, ctx)
+
+	const (
+		orgID = "org-1"
+		wsID  = "ws-1"
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/organization/"+orgID+"/workspace/"+wsID, func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(w, `{"data":{"type":"workspace","id":"ws-1","attributes":{`+
+			`"name":"my-workspace","description":null,"source":"https://example.com/repo.git",`+
+			`"branch":"main","folder":"/","defaultTemplate":"tmpl-1","iacType":"terraform",`+
+			`"terraformVersion":"1.12.0","executionMode":"remote","allowRemoteApply":false},`+
+			`"relationships":{"project":{"data":null}}}}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceVcsResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	base := map[string]tftypes.Value{
+		"id":                 tftypes.NewValue(tftypes.String, wsID),
+		"organization_id":    tftypes.NewValue(tftypes.String, orgID),
+		"name":               tftypes.NewValue(tftypes.String, "my-workspace"),
+		"repository":         tftypes.NewValue(tftypes.String, "https://example.com/repo.git"),
+		"template_id":        tftypes.NewValue(tftypes.String, "tmpl-1"),
+		"iac_version":        tftypes.NewValue(tftypes.String, "1.12.0"),
+		"branch":             tftypes.NewValue(tftypes.String, "main"),
+		"folder":             tftypes.NewValue(tftypes.String, "/"),
+		"iac_type":           tftypes.NewValue(tftypes.String, "terraform"),
+		"execution_mode":     tftypes.NewValue(tftypes.String, "remote"),
+		"allow_remote_apply": tftypes.NewValue(tftypes.Bool, false),
+	}
+
+	// Prior state had a project_id set (e.g. assigned outside Terraform, or
+	// by a previous apply); the new plan drops it.
+	stateOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		stateOverrides[k] = v
+	}
+	stateOverrides["project_id"] = tftypes.NewValue(tftypes.String, "old-project")
+
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		planOverrides[k] = v
+	}
+	planOverrides["project_id"] = tftypes.NewValue(tftypes.String, tftypes.UnknownValue)
+
+	req := resource.UpdateRequest{
+		State: tfsdk.State{Schema: s, Raw: buildObjectValue(objType, stateOverrides)},
+		Plan:  tfsdk.Plan{Schema: s, Raw: buildObjectValue(objType, planOverrides)},
+	}
+	resp := &resource.UpdateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Update(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	var result WorkspaceVcsResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if result.ProjectId.IsUnknown() {
+		t.Error("expected project_id to be resolved to null after update, but it is still unknown (Terraform's protocol rejects unknown values after apply)")
+	}
+	if !result.ProjectId.IsNull() {
+		t.Errorf("expected project_id to be null after update since the API returned no project, got: %v", result.ProjectId)
+	}
+}

--- a/internal/provider/workspace_webhook_event_resource.go
+++ b/internal/provider/workspace_webhook_event_resource.go
@@ -127,6 +127,9 @@ func (r *WorkspaceWebhookEventResource) Schema(ctx context.Context, req resource
 			"webhook_id": schema.StringAttribute{
 				Required:    true,
 				Description: "The ID of the webhook this event belongs to",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"path": schema.ListAttribute{
 				Optional:    true,
@@ -267,6 +270,7 @@ func (r *WorkspaceWebhookEventResource) Create(ctx context.Context, req resource
 		return
 	}
 
+	priority := plan.Priority.ValueInt64()
 	atomicOperation := map[string]interface{}{
 		"atomic:operations": []map[string]interface{}{
 			{
@@ -276,7 +280,7 @@ func (r *WorkspaceWebhookEventResource) Create(ctx context.Context, req resource
 					"type": "webhook_event",
 					"id":   eventID,
 					"attributes": map[string]interface{}{
-						"priority":          plan.Priority.ValueInt64(),
+						"priority":          priority,
 						"event":             plan.Event.ValueString(),
 						"branch":            strings.Join(branchList, ","),
 						"path":              strings.Join(pathList, ","),
@@ -388,6 +392,7 @@ func (r *WorkspaceWebhookEventResource) Create(ctx context.Context, req resource
 
 	result := atomicResp.AtomicResults[0]
 	plan.ID = types.StringValue(result.Data.ID)
+	plan.Priority = types.Int64Value(priority)
 
 	tflog.Info(ctx, "Workspace Webhook Event Resource Created", map[string]any{"success": true})
 
@@ -551,149 +556,91 @@ func (r *WorkspaceWebhookEventResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	// First, get the webhook details to get organization and workspace IDs
-	webhookRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/webhook/%s", r.endpoint, state.WebhookId.ValueString()), nil)
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/webhook_event/%s", r.endpoint, state.ID.ValueString()), nil)
 	if err != nil {
-		resp.Diagnostics.AddError("Error creating webhook read request", fmt.Sprintf("Error creating webhook read request: %s", err))
+		resp.Diagnostics.AddError("Error creating workspace webhook event resource request", fmt.Sprintf("Error creating workspace webhook event resource request: %s", err))
+		return
+	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	request.Header.Add("Content-Type", "application/vnd.api+json")
+
+	response, err := r.client.Do(request)
+	if err != nil {
+		resp.Diagnostics.AddError("Error executing workspace webhook event resource request", fmt.Sprintf("Error executing workspace webhook event resource request: %s", err))
+		return
+	}
+	defer response.Body.Close()
+
+	bodyResponse, err := io.ReadAll(response.Body)
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading workspace webhook event resource response", fmt.Sprintf("Error reading workspace webhook event resource response: %s", err))
 		return
 	}
 
-	webhookRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	webhookRequest.Header.Add("Content-Type", "application/vnd.api+json")
-
-	webhookResponse, err := r.client.Do(webhookRequest)
-	if err != nil {
-		resp.Diagnostics.AddError("Error executing webhook read request", fmt.Sprintf("Error executing webhook read request: %s", err))
-		return
-	}
-
-	webhookBody, err := io.ReadAll(webhookResponse.Body)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading webhook response", fmt.Sprintf("Error reading webhook response: %s", err))
-		return
-	}
-
-	tflog.Debug(ctx, "Read webhook response", map[string]any{
-		"status_code": webhookResponse.StatusCode,
-		"body":        string(webhookBody),
+	tflog.Debug(ctx, "Read webhook event response", map[string]any{
+		"status_code": response.StatusCode,
+		"body":        string(bodyResponse),
 	})
 
-	if webhookResponse.StatusCode == http.StatusNotFound {
+	if response.StatusCode == http.StatusNotFound {
 		resp.State.RemoveResource(ctx)
 		return
 	}
 
-	var webhookDetails webhookAPIResponse
-	if err := json.Unmarshal(webhookBody, &webhookDetails); err != nil {
-		resp.Diagnostics.AddError("Error parsing webhook response", fmt.Sprintf("Error parsing webhook response: %s", err))
+	if response.StatusCode != http.StatusOK {
+		resp.Diagnostics.AddError("Error reading workspace webhook event", fmt.Sprintf("Received non-200 status code: %d, body: %s", response.StatusCode, string(bodyResponse)))
 		return
 	}
 
-	tflog.Debug(ctx, "Parsed webhook details", map[string]any{
-		"organization_id": webhookDetails.Data.Relationships.Organization.Data.ID,
-		"workspace_id":    webhookDetails.Data.Relationships.Workspace.Data.ID,
-		"webhook_id":      webhookDetails.Data.ID,
-	})
-
-	workspaceId := webhookDetails.Data.Relationships.Workspace.Data.ID
-	if workspaceId == "" {
-		resp.Diagnostics.AddError("Invalid webhook response", "Could not determine Workspace ID from webhook response")
-		return
-	}
-
-	// Get organization ID from workspace
-	workspaceRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/workspace/%s", r.endpoint, workspaceId), nil)
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating workspace request", fmt.Sprintf("Error creating workspace request: %s", err))
-		return
-	}
-
-	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceRequest.Header.Add("Content-Type", "application/vnd.api+json")
-
-	workspaceResponse, err := r.client.Do(workspaceRequest)
-	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace request", fmt.Sprintf("Error executing workspace request: %s", err))
-		return
-	}
-
-	workspaceBody, err := io.ReadAll(workspaceResponse.Body)
-	if err != nil {
-		resp.Diagnostics.AddError("Error reading workspace response", fmt.Sprintf("Error reading workspace response: %s", err))
-		return
-	}
-
-	tflog.Debug(ctx, "Read workspace response", map[string]any{
-		"status_code": workspaceResponse.StatusCode,
-		"body":        string(workspaceBody),
-	})
-
-	if workspaceResponse.StatusCode == http.StatusNotFound {
-		resp.Diagnostics.AddError("Workspace not found", fmt.Sprintf("Workspace with ID %s not found", workspaceId))
-		return
-	}
-
-	var workspaceResp struct {
+	var eventResp struct {
 		Data struct {
 			Type       string `json:"type"`
 			ID         string `json:"id"`
 			Attributes struct {
-				Name string `json:"name"`
+				Branch            string `json:"branch"`
+				Path              string `json:"path"`
+				TemplateId        string `json:"templateId"`
+				Event             string `json:"event"`
+				Priority          int    `json:"priority"`
+				PrWorkflowEnabled bool   `json:"prWorkflowEnabled"`
+				PrApplyEnabled    bool   `json:"prApplyEnabled"`
 			} `json:"attributes"`
 			Relationships struct {
-				Organization struct {
+				Webhook struct {
 					Data struct {
 						Type string `json:"type"`
 						ID   string `json:"id"`
 					} `json:"data"`
-				} `json:"organization"`
+				} `json:"webhook"`
 			} `json:"relationships"`
 		} `json:"data"`
 	}
 
-	if err := json.Unmarshal(workspaceBody, &workspaceResp); err != nil {
-		resp.Diagnostics.AddError("Error parsing workspace response", fmt.Sprintf("Error parsing workspace response: %s", err))
+	if err := json.Unmarshal(bodyResponse, &eventResp); err != nil {
+		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response: %s", err))
 		return
 	}
 
-	organizationId := workspaceResp.Data.Relationships.Organization.Data.ID
-	if organizationId == "" {
-		resp.Diagnostics.AddError("Invalid workspace response", "Could not determine Organization ID from workspace response")
-		return
-	}
+	state.ID = types.StringValue(eventResp.Data.ID)
+	state.WebhookId = types.StringValue(eventResp.Data.Relationships.Webhook.Data.ID)
+	state.Event = types.StringValue(eventResp.Data.Attributes.Event)
+	state.TemplateId = types.StringValue(eventResp.Data.Attributes.TemplateId)
+	state.Priority = types.Int64Value(int64(eventResp.Data.Attributes.Priority))
+	state.PrWorkflowEnabled = types.BoolValue(eventResp.Data.Attributes.PrWorkflowEnabled)
+	state.PrApplyEnabled = types.BoolValue(eventResp.Data.Attributes.PrApplyEnabled)
 
-	tflog.Debug(ctx, "Parsed workspace details", map[string]any{
-		"organization_id": organizationId,
-		"workspace_id":    workspaceId,
-	})
+	branchList, branchDiags := types.ListValueFrom(ctx, types.StringType, strings.Split(eventResp.Data.Attributes.Branch, ","))
+	resp.Diagnostics.Append(branchDiags...)
+	state.Branch = branchList
 
-	var branchList, pathList []string
-	if !state.Branch.IsNull() && !state.Branch.IsUnknown() {
-		resp.Diagnostics.Append(state.Branch.ElementsAs(ctx, &branchList, false)...)
-	}
-	if !state.Path.IsNull() && !state.Path.IsUnknown() {
-		resp.Diagnostics.Append(state.Path.ElementsAs(ctx, &pathList, false)...)
-	}
+	pathList, pathDiags := types.ListValueFrom(ctx, types.StringType, strings.Split(eventResp.Data.Attributes.Path, ","))
+	resp.Diagnostics.Append(pathDiags...)
+	state.Path = pathList
+
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Check if the event ID exists in the webhook's events relationship
-	eventFound := false
-	for _, event := range webhookDetails.Data.Relationships.Events.Data {
-		if event.ID == state.ID.ValueString() {
-			eventFound = true
-			break
-		}
-	}
-
-	if !eventFound {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
-	// Since we found the event in the webhook's relationships, we can keep the state as is
-	// The event details are not critical for the resource to function
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -712,8 +659,12 @@ func (r *WorkspaceWebhookEventResource) Update(ctx context.Context, req resource
 		return
 	}
 
-	// First, get the webhook details to get organization and workspace IDs
-	webhookRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/webhook/%s", r.endpoint, state.WebhookId.ValueString()), nil)
+	// Look up the webhook via plan.WebhookId, not state.WebhookId: when the
+	// parent terrakube_workspace_webhook_v2 is replaced (taint, or any other
+	// forced recreation), webhook_id changes and state still holds the old,
+	// now-deleted webhook's ID. Looking it up by the old ID here would 404
+	// even though the update itself is perfectly valid against the new one.
+	webhookRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/webhook/%s", r.endpoint, plan.WebhookId.ValueString()), nil)
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating webhook read request", fmt.Sprintf("Error creating webhook read request: %s", err))
 		return
@@ -735,7 +686,7 @@ func (r *WorkspaceWebhookEventResource) Update(ctx context.Context, req resource
 	}
 
 	if webhookResponse.StatusCode == http.StatusNotFound {
-		resp.Diagnostics.AddError("Webhook not found", fmt.Sprintf("Webhook with ID %s not found", state.WebhookId.ValueString()))
+		resp.Diagnostics.AddError("Webhook not found", fmt.Sprintf("Webhook with ID %s not found", plan.WebhookId.ValueString()))
 		return
 	}
 
@@ -841,7 +792,7 @@ func (r *WorkspaceWebhookEventResource) Update(ctx context.Context, req resource
 				"href": fmt.Sprintf("/organization/%s/workspace/%s/webhook/%s/events/%s",
 					organizationId,
 					workspaceId,
-					state.WebhookId.ValueString(),
+					plan.WebhookId.ValueString(),
 					state.ID.ValueString()),
 				"data": map[string]interface{}{
 					"type": "webhook_event",
@@ -962,7 +913,7 @@ func (r *WorkspaceWebhookEventResource) Update(ctx context.Context, req resource
 		r.endpoint,
 		organizationId,
 		workspaceId,
-		state.WebhookId.ValueString()), nil)
+		plan.WebhookId.ValueString()), nil)
 	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	request.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {

--- a/internal/provider/workspace_webhook_event_resource.go
+++ b/internal/provider/workspace_webhook_event_resource.go
@@ -320,7 +320,7 @@ func (r *WorkspaceWebhookEventResource) Create(ctx context.Context, req resource
 		tflog.Error(ctx, "Failed to execute webhook event request", map[string]any{
 			"error": err.Error(),
 		})
-		resp.Diagnostics.AddError("Error executing workspace webhook event resource request", fmt.Sprintf("Error executing workspace webhook event resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook event resource request", fmt.Sprintf("Error executing workspace webhook event resource request: %s", err))
 		return
 	}
 
@@ -329,7 +329,7 @@ func (r *WorkspaceWebhookEventResource) Create(ctx context.Context, req resource
 		tflog.Error(ctx, "Failed to read webhook event response", map[string]any{
 			"error": err.Error(),
 		})
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook event resource, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook event resource, response status %s, error: %s", response.Status, err))
 	}
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
@@ -500,7 +500,7 @@ func (r *WorkspaceWebhookEventResource) Delete(ctx context.Context, req resource
 		tflog.Error(ctx, "Failed to execute webhook event delete request", map[string]any{
 			"error": err.Error(),
 		})
-		resp.Diagnostics.AddError("Error executing workspace webhook event resource request", fmt.Sprintf("Error executing workspace webhook event resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook event resource request", fmt.Sprintf("Error executing workspace webhook event resource request: %s", err))
 		return
 	}
 
@@ -509,7 +509,7 @@ func (r *WorkspaceWebhookEventResource) Delete(ctx context.Context, req resource
 		tflog.Error(ctx, "Failed to read webhook event delete response", map[string]any{
 			"error": err.Error(),
 		})
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook event resource, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook event resource, response status %s, error: %s", response.Status, err))
 	}
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
@@ -891,7 +891,7 @@ func (r *WorkspaceWebhookEventResource) Update(ctx context.Context, req resource
 		tflog.Error(ctx, "Failed to execute webhook event request", map[string]any{
 			"error": err.Error(),
 		})
-		resp.Diagnostics.AddError("Error executing workspace webhook event resource request", fmt.Sprintf("Error executing workspace webhook event resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook event resource request", fmt.Sprintf("Error executing workspace webhook event resource request: %s", err))
 		return
 	}
 
@@ -900,7 +900,7 @@ func (r *WorkspaceWebhookEventResource) Update(ctx context.Context, req resource
 		tflog.Error(ctx, "Failed to read webhook event response", map[string]any{
 			"error": err.Error(),
 		})
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook event resource, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook event resource, response status %s, error: %s", response.Status, err))
 	}
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {

--- a/internal/provider/workspace_webhook_event_resource_test.go
+++ b/internal/provider/workspace_webhook_event_resource_test.go
@@ -86,6 +86,40 @@ func TestWorkspaceWebhookEventResource_Schema_PrToggles(t *testing.T) {
 	}
 }
 
+// TestWorkspaceWebhookEventResource_Schema_WebhookIdRequiresReplace covers a
+// real bug: webhook_id was a plain Required string with no plan modifiers, so
+// Terraform planned a change to it as an in-place update. But the server
+// cascade-deletes a webhook's events when the webhook itself is destroyed
+// (e.g. the parent terrakube_workspace_webhook_v2 being tainted or otherwise
+// replaced) — there is nothing left server-side to "update," so the planned
+// update 404s with "Unknown identifier ... for events". webhook_id changing
+// must force replacement of the event instead.
+func TestWorkspaceWebhookEventResource_Schema_WebhookIdRequiresReplace(t *testing.T) {
+	ctx := context.Background()
+	s, _ := webhookEventSchemaAndType(t, ctx)
+
+	attr, ok := s.Attributes["webhook_id"]
+	if !ok {
+		t.Fatal("expected schema to define attribute \"webhook_id\"")
+	}
+
+	stringAttr, ok := attr.(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected webhook_id to be a StringAttribute, got %T", attr)
+	}
+
+	found := false
+	for _, m := range stringAttr.PlanModifiers {
+		if strings.Contains(m.Description(ctx), "destroy and recreate the resource") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected webhook_id to have a RequiresReplace plan modifier, so a change forces recreation instead of a doomed in-place update against a cascade-deleted event")
+	}
+}
+
 func TestWorkspaceWebhookEventResource_Create_SendsPrToggles(t *testing.T) {
 	ctx := context.Background()
 	s, objType := webhookEventSchemaAndType(t, ctx)
@@ -152,6 +186,69 @@ func TestWorkspaceWebhookEventResource_Create_SendsPrToggles(t *testing.T) {
 	}
 	if !result.PrApplyEnabled.ValueBool() {
 		t.Error("expected pr_apply_enabled to remain true in state after create")
+	}
+}
+
+// TestWorkspaceWebhookEventResource_Create_ResolvesPriorityWhenUnset covers
+// a real bug: priority is Optional+Computed with no Default and no
+// UseStateForUnknown plan modifier, so Terraform leaves it unknown (not
+// null) during Create when it's absent from config. Create() never wrote
+// the value it actually sent back into state, so Terraform's protocol
+// rejected the result as still-unknown-after-apply.
+func TestWorkspaceWebhookEventResource_Create_ResolvesPriorityWhenUnset(t *testing.T) {
+	ctx := context.Background()
+	s, objType := webhookEventSchemaAndType(t, ctx)
+
+	const webhookID = "wh-create-2"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/webhook/"+webhookID, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data":{"type":"webhook","id":%q,"attributes":{"name":"wh"},`+
+			`"relationships":{"organization":{"data":{"type":"organization","id":"org-1"}},`+
+			`"workspace":{"data":{"type":"workspace","id":"ws-1"}},"events":{"data":[]}}}}`, webhookID)
+	})
+	mux.HandleFunc("/api/v1/operations", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"atomic:results":[{"data":{"type":"webhook_event","id":"event-created-2"}}]}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceWebhookEventResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	planValue := buildObjectValue(objType, map[string]tftypes.Value{
+		"webhook_id":  tftypes.NewValue(tftypes.String, webhookID),
+		"event":       tftypes.NewValue(tftypes.String, "PUSH"),
+		"template_id": tftypes.NewValue(tftypes.String, "tmpl-1"),
+		// priority intentionally left unknown, matching what Terraform
+		// actually produces for an Optional+Computed attribute that's
+		// absent from config during Create (never null).
+		"priority": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+	})
+
+	req := resource.CreateRequest{Plan: tfsdk.Plan{Schema: s, Raw: planValue}}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	var result WorkspaceWebhookEventResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if result.Priority.IsUnknown() {
+		t.Fatal("expected priority to be resolved to a known value after create, but it is still unknown (Terraform's protocol rejects unknown values after apply)")
+	}
+	if result.Priority.ValueInt64() != 0 {
+		t.Errorf("expected priority to resolve to 0 (the value actually sent), got %d", result.Priority.ValueInt64())
 	}
 }
 
@@ -261,5 +358,221 @@ func TestWorkspaceWebhookEventResource_Update_RoundTripsPrToggles(t *testing.T) 
 	}
 	if result.PrApplyEnabled.ValueBool() {
 		t.Error("expected pr_apply_enabled read back from the API to be false")
+	}
+}
+
+// TestWorkspaceWebhookEventResource_Read_DetectsDrift covers a real bug:
+// Read() used to only check whether the event's ID still appeared in its
+// parent webhook's events relationship, then write the untouched prior state
+// straight back — it never actually re-fetched the event's own attributes.
+// Any out-of-band change (a toggle flipped directly via the API, a priority
+// changed by another apply) was invisible to `terraform plan`. Confirmed live
+// against a real API: changing pr_apply_enabled directly in the database and
+// running `terraform plan` reported no changes.
+func TestWorkspaceWebhookEventResource_Read_DetectsDrift(t *testing.T) {
+	ctx := context.Background()
+	s, objType := webhookEventSchemaAndType(t, ctx)
+
+	const (
+		webhookID = "wh-read-drift-1"
+		eventID   = "event-read-drift-1"
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/webhook_event/"+eventID, func(w http.ResponseWriter, _ *http.Request) {
+		// The server reports values that differ from what's in prior state
+		// below on every field, simulating drift introduced outside Terraform.
+		fmt.Fprintf(w, `{"data":{"type":"webhook_event","id":%q,"attributes":{`+
+			`"branch":"develop","path":"other/","templateId":"tmpl-2","event":"PUSH","priority":7,`+
+			`"prWorkflowEnabled":false,"prApplyEnabled":false},`+
+			`"relationships":{"webhook":{"data":{"type":"webhook","id":%q}}}}}`, eventID, webhookID)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceWebhookEventResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	staleState := buildObjectValue(objType, map[string]tftypes.Value{
+		"id":                  tftypes.NewValue(tftypes.String, eventID),
+		"webhook_id":          tftypes.NewValue(tftypes.String, webhookID),
+		"event":               tftypes.NewValue(tftypes.String, "PULL_REQUEST"),
+		"priority":            tftypes.NewValue(tftypes.Number, big.NewFloat(1)),
+		"template_id":         tftypes.NewValue(tftypes.String, "tmpl-1"),
+		"pr_workflow_enabled": tftypes.NewValue(tftypes.Bool, true),
+		"pr_apply_enabled":    tftypes.NewValue(tftypes.Bool, true),
+	})
+
+	req := resource.ReadRequest{State: tfsdk.State{Schema: s, Raw: staleState}}
+	resp := &resource.ReadResponse{State: tfsdk.State{Schema: s, Raw: staleState}}
+
+	r.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	var result WorkspaceWebhookEventResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if result.Event.ValueString() != "PUSH" {
+		t.Errorf("expected event refreshed to PUSH (the real server value), got %q", result.Event.ValueString())
+	}
+	if result.Priority.ValueInt64() != 7 {
+		t.Errorf("expected priority refreshed to 7, got %d", result.Priority.ValueInt64())
+	}
+	if result.TemplateId.ValueString() != "tmpl-2" {
+		t.Errorf("expected template_id refreshed to tmpl-2, got %q", result.TemplateId.ValueString())
+	}
+	if result.PrWorkflowEnabled.ValueBool() {
+		t.Error("expected pr_workflow_enabled refreshed to false")
+	}
+	if result.PrApplyEnabled.ValueBool() {
+		t.Error("expected pr_apply_enabled refreshed to false")
+	}
+}
+
+func TestWorkspaceWebhookEventResource_Read_RemovesResourceWhenEventDeleted(t *testing.T) {
+	ctx := context.Background()
+	s, objType := webhookEventSchemaAndType(t, ctx)
+
+	const eventID = "event-read-gone-1"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/webhook_event/"+eventID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"errors":[{"detail":"Unknown identifier"}]}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceWebhookEventResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	staleState := buildObjectValue(objType, map[string]tftypes.Value{
+		"id":         tftypes.NewValue(tftypes.String, eventID),
+		"webhook_id": tftypes.NewValue(tftypes.String, "wh-1"),
+	})
+
+	req := resource.ReadRequest{State: tfsdk.State{Schema: s, Raw: staleState}}
+	resp := &resource.ReadResponse{State: tfsdk.State{Schema: s, Raw: staleState}}
+
+	r.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Read returned diagnostics: %v", resp.Diagnostics)
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Error("expected state to be removed after a 404 from the API")
+	}
+}
+
+// TestWorkspaceWebhookEventResource_Update_UsesPlanWebhookIdNotStaleState
+// covers a real bug: Update() looked up the webhook via state.WebhookId (the
+// prior value) instead of plan.WebhookId (the value being applied). When the
+// parent terrakube_workspace_webhook_v2 is replaced (taint, or any other
+// forced recreation), webhook_id changes and the old ID no longer exists —
+// Update() then failed with "Webhook not found" even though the update
+// itself was perfectly valid against the new webhook. Confirmed live: taint
+// + apply on the parent webhook_v2 broke every dependent webhook_event.
+func TestWorkspaceWebhookEventResource_Update_UsesPlanWebhookIdNotStaleState(t *testing.T) {
+	ctx := context.Background()
+	s, objType := webhookEventSchemaAndType(t, ctx)
+
+	const (
+		oldWebhookID = "wh-old-destroyed"
+		newWebhookID = "wh-new-replacement"
+		workspaceID  = "ws-taint-1"
+		orgID        = "org-taint-1"
+		eventID      = "event-taint-1"
+	)
+
+	mux := http.NewServeMux()
+	// The old webhook was destroyed by the parent resource's replacement —
+	// looking it up must not happen, and if it does, this 404s the test.
+	mux.HandleFunc("/api/v1/webhook/"+oldWebhookID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"errors":[{"detail":"Unknown identifier"}]}`)
+	})
+	mux.HandleFunc("/api/v1/webhook/"+newWebhookID, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data":{"type":"webhook","id":%q,"attributes":{"name":"wh"},`+
+			`"relationships":{"organization":{"data":{"type":"organization","id":%q}},`+
+			`"workspace":{"data":{"type":"workspace","id":%q}},"events":{"data":[]}}}}`,
+			newWebhookID, orgID, workspaceID)
+	})
+	mux.HandleFunc("/api/v1/workspace/"+workspaceID, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data":{"type":"workspace","id":%q,"attributes":{"name":"ws"},`+
+			`"relationships":{"organization":{"data":{"type":"organization","id":%q}}}}}`,
+			workspaceID, orgID)
+	})
+	mux.HandleFunc("/api/v1/operations", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"atomic:results":[{"data":{"type":"webhook_event","id":%q}}]}`, eventID)
+	})
+	eventsPath := fmt.Sprintf("/api/v1/organization/%s/workspace/%s/webhook/%s/events", orgID, workspaceID, newWebhookID)
+	mux.HandleFunc(eventsPath, func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, `{"data":[{"type":"webhook_event","id":%q,"attributes":{`+
+			`"branch":"main","path":"/","templateId":"tmpl-1","event":"PULL_REQUEST","priority":1,`+
+			`"prWorkflowEnabled":false,"prApplyEnabled":false},`+
+			`"relationships":{"webhook":{"data":{"type":"webhook","id":%q}}}}]}`, eventID, newWebhookID)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceWebhookEventResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	base := map[string]tftypes.Value{
+		"id":                  tftypes.NewValue(tftypes.String, eventID),
+		"event":               tftypes.NewValue(tftypes.String, "PULL_REQUEST"),
+		"priority":            tftypes.NewValue(tftypes.Number, big.NewFloat(1)),
+		"template_id":         tftypes.NewValue(tftypes.String, "tmpl-1"),
+		"pr_workflow_enabled": tftypes.NewValue(tftypes.Bool, false),
+		"pr_apply_enabled":    tftypes.NewValue(tftypes.Bool, false),
+	}
+
+	stateOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		stateOverrides[k] = v
+	}
+	stateOverrides["webhook_id"] = tftypes.NewValue(tftypes.String, oldWebhookID)
+
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		planOverrides[k] = v
+	}
+	planOverrides["webhook_id"] = tftypes.NewValue(tftypes.String, newWebhookID)
+
+	req := resource.UpdateRequest{
+		State: tfsdk.State{Schema: s, Raw: buildObjectValue(objType, stateOverrides)},
+		Plan:  tfsdk.Plan{Schema: s, Raw: buildObjectValue(objType, planOverrides)},
+	}
+	resp := &resource.UpdateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Update(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned diagnostics (should have used plan.WebhookId, not the destroyed state.WebhookId): %v", resp.Diagnostics)
+	}
+
+	var result WorkspaceWebhookEventResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+	if result.WebhookId.ValueString() != newWebhookID {
+		t.Errorf("expected webhook_id in state to be the new webhook %q, got %q", newWebhookID, result.WebhookId.ValueString())
 	}
 }

--- a/internal/provider/workspace_webhook_resource.go
+++ b/internal/provider/workspace_webhook_resource.go
@@ -177,20 +177,20 @@ func (r *WorkspaceWebhookResource) Create(ctx context.Context, req resource.Crea
 
 	response, err := r.client.Do(request)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err := io.ReadAll(response.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook resource, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook resource, response status %s, error: %s", response.Status, err))
 	}
 	webhook := &client.WorkspaceWebhookEntity{}
 
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), webhook)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response: response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response: response status %s, response body: %s, error: %s", response.Status, string(bodyResponse), err))
 		return
 	}
 
@@ -226,7 +226,7 @@ func (r *WorkspaceWebhookResource) Read(ctx context.Context, req resource.ReadRe
 
 	response, err := r.client.Do(request)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request: %s", err))
 		return
 	}
 
@@ -238,7 +238,7 @@ func (r *WorkspaceWebhookResource) Read(ctx context.Context, req resource.ReadRe
 
 	bodyResponse, err := io.ReadAll(response.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook resource response, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook resource response, response status %s, error: %s", response.Status, err))
 	}
 	webhook := &client.WorkspaceWebhookEntity{}
 
@@ -246,7 +246,7 @@ func (r *WorkspaceWebhookResource) Read(ctx context.Context, req resource.ReadRe
 	err = jsonapi.UnmarshalPayload(strings.NewReader(string(bodyResponse)), webhook)
 
 	if err != nil {
-		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error unmarshal payload response", fmt.Sprintf("Error unmarshal payload response, response status %s, response body: %s, error: %s", response.Status, string(bodyResponse), err))
 		return
 	}
 
@@ -309,13 +309,13 @@ func (r *WorkspaceWebhookResource) Update(ctx context.Context, req resource.Upda
 
 	response, err := r.client.Do(request)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err := io.ReadAll(response.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading Workspace webhook resource response, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading Workspace webhook resource response, response status %s, error: %s", response.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
@@ -330,13 +330,13 @@ func (r *WorkspaceWebhookResource) Update(ctx context.Context, req resource.Upda
 
 	response, err = r.client.Do(request)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err = io.ReadAll(response.Body)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading workspace webhook resource response body", fmt.Sprintf("Error reading workspace webhook resource response body, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error reading workspace webhook resource response body", fmt.Sprintf("Error reading workspace webhook resource response body, response status %s, error: %s", response.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
@@ -377,8 +377,13 @@ func (r *WorkspaceWebhookResource) Delete(ctx context.Context, req resource.Dele
 	}
 
 	response, err := r.client.Do(request)
-	if err != nil || response.StatusCode != http.StatusNoContent {
-		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+	if err != nil {
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request: %s", err))
+		return
+	}
+	if response.StatusCode != http.StatusNoContent {
+		deleteBody, _ := io.ReadAll(response.Body)
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s", response.Status, string(deleteBody)))
 		return
 	}
 }

--- a/internal/provider/workspace_webhook_v2_resource.go
+++ b/internal/provider/workspace_webhook_v2_resource.go
@@ -188,7 +188,7 @@ func (r *WorkspaceWebhookV2Resource) Create(ctx context.Context, req resource.Cr
 		tflog.Error(ctx, "Failed to execute webhook request", map[string]any{
 			"error": err.Error(),
 		})
-		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request: %s", err))
 		return
 	}
 
@@ -197,7 +197,7 @@ func (r *WorkspaceWebhookV2Resource) Create(ctx context.Context, req resource.Cr
 		tflog.Error(ctx, "Failed to read webhook response", map[string]any{
 			"error": err.Error(),
 		})
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook resource, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook resource, response status %s, error: %s", response.Status, err))
 	}
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
@@ -374,13 +374,13 @@ func (r *WorkspaceWebhookV2Resource) Update(ctx context.Context, req resource.Up
 
 	response, err := r.client.Do(request)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err := io.ReadAll(response.Body)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook resource response, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		tflog.Error(ctx, fmt.Sprintf("Error reading workspace webhook resource response, response status %s, error: %s", response.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
@@ -407,13 +407,13 @@ func (r *WorkspaceWebhookV2Resource) Update(ctx context.Context, req resource.Up
 
 	response, err = r.client.Do(request)
 	if err != nil {
-		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request: %s", err))
 		return
 	}
 
 	bodyResponse, err = io.ReadAll(response.Body)
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading workspace webhook resource response body", fmt.Sprintf("Error reading workspace webhook resource response body, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+		resp.Diagnostics.AddError("Error reading workspace webhook resource response body", fmt.Sprintf("Error reading workspace webhook resource response body, response status %s, error: %s", response.Status, err))
 	}
 
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": string(bodyResponse)})
@@ -463,8 +463,13 @@ func (r *WorkspaceWebhookV2Resource) Delete(ctx context.Context, req resource.De
 	}
 
 	response, err := r.client.Do(request)
-	if err != nil || response.StatusCode != http.StatusNoContent {
-		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s, error: %s", response.Status, response.Body, err))
+	if err != nil {
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request: %s", err))
+		return
+	}
+	if response.StatusCode != http.StatusNoContent {
+		deleteBody, _ := io.ReadAll(response.Body)
+		resp.Diagnostics.AddError("Error executing workspace webhook resource request", fmt.Sprintf("Error executing workspace webhook resource request, response status %s, response body: %s", response.Status, string(deleteBody)))
 		return
 	}
 }

--- a/internal/provider/workspace_webhook_v2_resource.go
+++ b/internal/provider/workspace_webhook_v2_resource.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"terraform-provider-terrakube/internal/client"
 
+	"github.com/google/jsonapi"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -133,6 +135,7 @@ func (r *WorkspaceWebhookV2Resource) Create(ctx context.Context, req resource.Cr
 		"id": webhookID,
 	})
 
+	migratedV2 := plan.MigratedV2.ValueBool()
 	atomicOperation := map[string]interface{}{
 		"atomic:operations": []map[string]interface{}{
 			{
@@ -142,7 +145,7 @@ func (r *WorkspaceWebhookV2Resource) Create(ctx context.Context, req resource.Cr
 					"type": "webhook",
 					"id":   webhookID,
 					"attributes": map[string]interface{}{
-						"migratedV2": plan.MigratedV2.ValueBool(),
+						"migratedV2": migratedV2,
 					},
 				},
 				"relationships": map[string]interface{}{
@@ -257,6 +260,7 @@ func (r *WorkspaceWebhookV2Resource) Create(ctx context.Context, req resource.Cr
 	result := atomicResp.AtomicResults[0]
 	plan.ID = types.StringValue(result.Data.ID)
 	plan.RemoteHookId = types.StringValue(result.Data.ID) // Using ID as RemoteHookId since it's not in the response
+	plan.MigratedV2 = types.BoolValue(migratedV2)
 
 	tflog.Debug(ctx, "Successfully created webhook", map[string]any{
 		"id":             result.Data.ID,
@@ -358,13 +362,13 @@ func (r *WorkspaceWebhookV2Resource) Update(ctx context.Context, req resource.Up
 		MigratedV2: &migratedV2,
 	}
 
-	jsonData, err := json.Marshal(bodyRequest)
-	if err != nil {
+	var out = new(bytes.Buffer)
+	if err := jsonapi.MarshalPayload(out, bodyRequest); err != nil {
 		resp.Diagnostics.AddError("Unable to marshal payload", fmt.Sprintf("Unable to marshal payload: %s", err))
 		return
 	}
 
-	request, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), strings.NewReader(string(jsonData)))
+	request, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
 	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	request.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {

--- a/internal/provider/workspace_webhook_v2_resource_test.go
+++ b/internal/provider/workspace_webhook_v2_resource_test.go
@@ -1,0 +1,182 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func workspaceWebhookV2SchemaAndType(t *testing.T, ctx context.Context) (schema.Schema, tftypes.Object) {
+	t.Helper()
+
+	r := &WorkspaceWebhookV2Resource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	objType, ok := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected schema type to be a tftypes.Object")
+	}
+
+	return schemaResp.Schema, objType
+}
+
+// TestWorkspaceWebhookV2Resource_Create_ResolvesMigratedV2WhenUnset covers a
+// real bug: migrated_v2 is Optional+Computed with no Default, so Terraform
+// leaves it unknown (not null) during Create when it's absent from config
+// (exactly how main.tf's `migrated_v2 = true` line was learned to be
+// necessary — without it the shared-webhook path never activates server
+// side). Create() never wrote the value it actually sent back into state,
+// so Terraform's protocol rejected the result as still-unknown-after-apply.
+func TestWorkspaceWebhookV2Resource_Create_ResolvesMigratedV2WhenUnset(t *testing.T) {
+	ctx := context.Background()
+	s, objType := workspaceWebhookV2SchemaAndType(t, ctx)
+
+	const orgID = "org-1"
+	const wsID = "ws-1"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/operations", func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		if strings.Contains(string(body), `"migratedV2":true`) {
+			t.Errorf("expected migratedV2:false to be sent when unset in config, got: %s", body)
+		}
+		fmt.Fprint(w, `{"atomic:results":[{"data":{"type":"webhook","id":"wh-created-1"}}]}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceWebhookV2Resource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	planValue := buildObjectValue(objType, map[string]tftypes.Value{
+		"organization_id": tftypes.NewValue(tftypes.String, orgID),
+		"workspace_id":    tftypes.NewValue(tftypes.String, wsID),
+		// migrated_v2 intentionally left unknown, matching what Terraform
+		// actually produces for an Optional+Computed attribute that's
+		// absent from config during Create (never null).
+		"migrated_v2": tftypes.NewValue(tftypes.Bool, tftypes.UnknownValue),
+	})
+
+	req := resource.CreateRequest{Plan: tfsdk.Plan{Schema: s, Raw: planValue}}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	var result WorkspaceWebhookV2ResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if result.MigratedV2.IsUnknown() {
+		t.Fatal("expected migrated_v2 to be resolved to a known value after create, but it is still unknown (Terraform's protocol rejects unknown values after apply)")
+	}
+	if result.MigratedV2.ValueBool() {
+		t.Errorf("expected migrated_v2 to resolve to false (the value actually sent), got true")
+	}
+}
+
+// TestWorkspaceWebhookV2Resource_Update_SendsValidJsonApiPayload covers a
+// real bug: Update() built its PATCH body with plain json.Marshal() on a
+// struct that only carries `jsonapi` tags, producing a flat, non-JSON:API
+// body (e.g. {"ID":"...","MigratedV2":true}) instead of the required
+// {"data":{"type":"webhook","attributes":{...}}} shape. Elide rejected it
+// with "Expected data but found null".
+func TestWorkspaceWebhookV2Resource_Update_SendsValidJsonApiPayload(t *testing.T) {
+	ctx := context.Background()
+	s, objType := workspaceWebhookV2SchemaAndType(t, ctx)
+
+	const (
+		orgID = "org-1"
+		wsID  = "ws-1"
+		id    = "wh-1"
+	)
+
+	var patchBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/organization/"+orgID+"/workspace/"+wsID+"/webhook/"+id, func(w http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodPatch {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("reading PATCH body: %v", err)
+			}
+			patchBody = string(body)
+			fmt.Fprint(w, `{"data":{"type":"webhook","id":"wh-1","attributes":{"migratedV2":true}}}`)
+			return
+		}
+		// Update()'s follow-up GET.
+		fmt.Fprint(w, `{"data":{"type":"webhook","id":"wh-1","attributes":{"remoteHookId":"","migratedV2":true}}}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceWebhookV2Resource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	base := map[string]tftypes.Value{
+		"id":              tftypes.NewValue(tftypes.String, id),
+		"organization_id": tftypes.NewValue(tftypes.String, orgID),
+		"workspace_id":    tftypes.NewValue(tftypes.String, wsID),
+		"remote_hook_id":  tftypes.NewValue(tftypes.String, ""),
+	}
+	stateOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		stateOverrides[k] = v
+	}
+	stateOverrides["migrated_v2"] = tftypes.NewValue(tftypes.Bool, false)
+
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		planOverrides[k] = v
+	}
+	planOverrides["migrated_v2"] = tftypes.NewValue(tftypes.Bool, true)
+
+	req := resource.UpdateRequest{
+		State: tfsdk.State{Schema: s, Raw: buildObjectValue(objType, stateOverrides)},
+		Plan:  tfsdk.Plan{Schema: s, Raw: buildObjectValue(objType, planOverrides)},
+	}
+	resp := &resource.UpdateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Update(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	if !strings.Contains(patchBody, `"data"`) {
+		t.Errorf("expected PATCH body to be JSON:API shaped (contain a top-level \"data\" key), got: %s", patchBody)
+	}
+	if !strings.Contains(patchBody, `"type":"webhook"`) {
+		t.Errorf("expected PATCH body to declare type \"webhook\", got: %s", patchBody)
+	}
+	if strings.Contains(patchBody, `"createdBy":""`) {
+		t.Errorf("expected read-only empty fields to be omitted from the PATCH body, got: %s", patchBody)
+	}
+}


### PR DESCRIPTION
## Problem

This branch fixes three separate classes of bugs found while building and testing the `terrakube_workspace_webhook_v2` / `terrakube_workspace_webhook_event` resources against the backend's new shared-webhook redesign, plus two provider-wide bugs found along the way:

**1. `project_id` unknown-vs-null on create (`workspace_vcs`, `workspace_cli`)**
`project_id` is `Optional+Computed` with no `Default`, so Terraform leaves it `Unknown` (not `Null`) during `Create()` when it's absent from config. Both resources only guarded against `IsNull()`, so an absent `project_id` sent a `"project"` relationship with an empty id, which the API rejected with a 404 the provider couldn't even unmarshal.

**2. Garbled/unreadable API error bodies across ~14 files**
Error diagnostics formatted `response.Body` (an `io.Reader`) directly with `%s` instead of the bytes actually read from it, producing unreadable garbage instead of the real API error message — making every failure in these resources far harder to diagnose than it needed to be.

**3. Webhook v2 resource bugs**
- `migrated_v2` (`workspace_webhook_v2`) and `priority` (`workspace_webhook_event`) are also `Optional+Computed` with no `Default`, and `Create()` never wrote the value it actually sent back into state — Terraform's protocol rejects the result as still-unknown-after-apply.
- `workspace_webhook_v2`'s `Update()` marshaled its request body with plain `json.Marshal()` instead of JSON:API, which the API rejected.
- `workspace_webhook_event`'s `Read()` only checked whether the event still existed in its parent webhook's relationship list — it never refreshed the event's own attributes, so `terraform plan` could never detect drift.
- `workspace_webhook_event`'s `Update()` looked up the webhook via the stale prior-state `webhook_id` instead of the planned one, and `webhook_id` had no `RequiresReplace` modifier — so replacing the parent `workspace_webhook_v2` (taint or any forced recreation) broke every dependent event.

## How it was reproduced

- **`project_id` unknown**: built raw `tftypes.Value` plan objects with `project_id` left `Unknown` (matching what Terraform actually sends on `Create()` for an absent Optional+Computed attribute) and confirmed the provider sent a broken relationship.
- **Garbled errors**: triggered real API error responses (invalid input, permission errors) and observed the diagnostic output was unreadable garbage instead of the actual JSON:API error detail.
- **`migrated_v2`/`priority` unknown-after-apply**: same `tftypes.Value`-with-`Unknown` technique as above.
- **`Update()` payload**: live-tested against a running devcontainer API and captured the actual rejected request body.
- **`Read()` drift**: live-tested end to end — created resources via Terraform, changed an attribute directly in the backend database (bypassing Terraform entirely), then ran `terraform plan` and confirmed it reported "No changes" despite the real value having changed.
- **`Update()`/taint replace bug**: tainted a `workspace_webhook_v2` resource and ran `terraform apply` — reproduced the exact `"Webhook not found"` error using the destroyed resource's old ID, then reproduced the missing-`RequiresReplace` gap by watching Terraform plan the dependent event as an in-place update instead of a replacement, which then failed against the server's cascade-deleted row.

## How it was solved

- Guard `project_id` handling against `IsUnknown()` as well as `IsNull()` on both `workspace_vcs` and `workspace_cli`, and resolve state to `null` instead of leaving it unknown when the API returns no project.
- Fix all ~14 files to read `response.Body` into bytes before formatting, and guard against nil-response panics when `client.Do()` itself fails.
- `Create()` for both webhook resources now writes the actual `migrated_v2` / `priority` value sent to the API back into state.
- `workspace_webhook_v2`'s `Update()` now uses `jsonapi.MarshalPayload()`, matching `Create()`.
- Rewrote `workspace_webhook_event`'s `Read()` to `GET /api/v1/webhook_event/{id}` directly and refresh every attribute (branch, path, event, template_id, priority, both PR toggles, and `webhook_id`) from the response.
- Fixed `Update()` to use `plan.WebhookId` instead of `state.WebhookId`, and added `RequiresReplace` on `webhook_id` so a change to it correctly forces recreation instead of a doomed in-place update.

## Tests added

- `workspace_vcs_resource_test.go` — regression coverage for the `project_id` unknown-vs-null fix and the garbled error-body fix, on both `Create()` and `Update()`.
- `TestWorkspaceWebhookV2Resource_Create_ResolvesMigratedV2WhenUnset`, `TestWorkspaceWebhookEventResource_Create_ResolvesPriorityWhenUnset` — cover the unknown-after-apply fix.
- `TestWorkspaceWebhookV2Resource_Update_SendsValidJsonApiPayload` — covers the `Update()` payload fix.
- `TestWorkspaceWebhookEventResource_Read_DetectsDrift`, `TestWorkspaceWebhookEventResource_Read_RemovesResourceWhenEventDeleted` — cover the `Read()` rewrite.
- `TestWorkspaceWebhookEventResource_Update_UsesPlanWebhookIdNotStaleState`, `TestWorkspaceWebhookEventResource_Schema_WebhookIdRequiresReplace` — cover the taint/replace fix.
- All fixes verified with the standard revert-fix-confirm-fails / restore-confirm-passes pattern, plus live end-to-end verification against a running devcontainer: create, update, delete, full destroy/recreate cycles, drift detection, and taint, all via the actual Terraform CLI against the live API.

## Companion PR

Goes along with [terrakube#3344](https://github.com/terrakube-io/terrakube/pull/3344) — the backend's Quartz-based shared-webhook redesign, which is what surfaced the `Read()`/`Update()`/`RequiresReplace` bugs here once resources were actually being created, drifted, and replaced against the new async sync path.