### PR TITLE
feat(workspace): add ssh_id and module_ssh_key for SSH-based repo access and module downloads

### DIFF
--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -38,7 +38,9 @@ data "terrakube_workspace" "ws" {
 - `iactype` (String) IaC type
 - `iacversion` (String) IaC version
 - `id` (String) Workspace Id
+- `module_ssh_key` (String) SSH key ID used to download private Terraform/OpenTofu modules referenced via git-based module sources within this workspace
 - `organization_id` (String) organization ID
 - `source` (String) Source
+- `sshid` (String) SSH key ID used to clone the workspace repository directly over SSH
 - `template_id` (String) template ID
 - `vcsid` (String) VCS ID

--- a/docs/resources/workspace_cli.md
+++ b/docs/resources/workspace_cli.md
@@ -39,6 +39,10 @@ resource "terrakube_workspace_cli" "sample3" {
   iac_type        = "terraform"
   iac_version     = "1.5.7"
   project_id      = terrakube_project.project.id
+
+  # Optional: use an org SSH key to download private Terraform/OpenTofu
+  # modules referenced via git-based module sources in this workspace.
+  module_ssh_key = terrakube_ssh.module_key.id
 }
 ```
 
@@ -56,6 +60,7 @@ resource "terrakube_workspace_cli" "sample3" {
 ### Optional
 
 - `description` (String) Workspace CLI description
+- `module_ssh_key` (String) SSH key ID (see terrakube_ssh) used to download private Terraform/OpenTofu modules referenced via git-based module sources within this workspace. Leave unset to leave any existing value untouched; set to an empty string to clear it.
 - `project_id` (String) Id of the project this workspace belongs to. Leave unset to leave any existing project assignment (e.g. made outside Terraform) untouched.
 
 ### Read-Only

--- a/docs/resources/workspace_vcs.md
+++ b/docs/resources/workspace_vcs.md
@@ -25,6 +25,25 @@ resource "terrakube_workspace_vcs" "sample1" {
   iac_type        = "terraform"
   iac_version     = "1.5.7"
   project_id      = terrakube_project.project.id
+
+  # Optional: use an org SSH key to download private Terraform/OpenTofu
+  # modules referenced via git-based module sources in this workspace.
+  module_ssh_key = terrakube_ssh.module_key.id
+}
+
+# Repository accessed over raw SSH instead of an OAuth VCS connection.
+# vcs_id and ssh_id are mutually exclusive.
+resource "terrakube_workspace_vcs" "sample2" {
+  organization_id = data.terrakube_organization.org.id
+  name            = "work-from-provider2"
+  execution_mode  = "remote"
+  repository      = "git@github.com:terrakube-io/terrakube-docker-compose.git"
+  branch          = "main"
+  folder          = "/"
+  template_id     = terrakube_organization_template.example.id
+  iac_type        = "terraform"
+  iac_version     = "1.5.7"
+  ssh_id          = terrakube_ssh.workspace_key.id
 }
 ```
 
@@ -47,7 +66,9 @@ resource "terrakube_workspace_vcs" "sample1" {
 - `execution_mode` (String) Workspace VCS execution mode (remote or local)
 - `folder` (String) Workspace VCS folder
 - `iac_type` (String) Workspace VCS IaC type (Supported values terraform or tofu)
+- `module_ssh_key` (String) SSH key ID (see terrakube_ssh) used to download private Terraform/OpenTofu modules referenced via git-based module sources within this workspace. This key is not used to clone the workspace repository itself; use vcs_id or ssh_id for that. Leave unset to leave any existing value untouched; set to an empty string to clear it.
 - `project_id` (String) Id of the project this workspace belongs to. Leave unset to leave any existing project assignment (e.g. made outside Terraform) untouched.
+- `ssh_id` (String) SSH key ID (see terrakube_ssh) used to clone the workspace repository directly over SSH (e.g. git@github.com:org/repo.git), as an alternative to an OAuth-based VCS connection. Mutually exclusive with vcs_id. Leave unset to leave any existing SSH key assignment untouched.
 - `vcs_id` (String) VCS connection ID for private workspaces
 
 ### Read-Only

--- a/examples/resources/terrakube_workspace_cli/resource.tf
+++ b/examples/resources/terrakube_workspace_cli/resource.tf
@@ -24,4 +24,8 @@ resource "terrakube_workspace_cli" "sample3" {
   iac_type        = "terraform"
   iac_version     = "1.5.7"
   project_id      = terrakube_project.project.id
+
+  # Optional: use an org SSH key to download private Terraform/OpenTofu
+  # modules referenced via git-based module sources in this workspace.
+  module_ssh_key = terrakube_ssh.module_key.id
 }

--- a/examples/resources/terrakube_workspace_vcs/resource.tf
+++ b/examples/resources/terrakube_workspace_vcs/resource.tf
@@ -10,4 +10,23 @@ resource "terrakube_workspace_vcs" "sample1" {
   iac_type        = "terraform"
   iac_version     = "1.5.7"
   project_id      = terrakube_project.project.id
+
+  # Optional: use an org SSH key to download private Terraform/OpenTofu
+  # modules referenced via git-based module sources in this workspace.
+  module_ssh_key = terrakube_ssh.module_key.id
+}
+
+# Repository accessed over raw SSH instead of an OAuth VCS connection.
+# vcs_id and ssh_id are mutually exclusive.
+resource "terrakube_workspace_vcs" "sample2" {
+  organization_id = data.terrakube_organization.org.id
+  name            = "work-from-provider2"
+  execution_mode  = "remote"
+  repository      = "git@github.com:terrakube-io/terrakube-docker-compose.git"
+  branch          = "main"
+  folder          = "/"
+  template_id     = terrakube_organization_template.example.id
+  iac_type        = "terraform"
+  iac_version     = "1.5.7"
+  ssh_id          = terrakube_ssh.workspace_key.id
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -71,8 +71,10 @@ type WorkspaceEntity struct {
 	ExecutionMode    string         `jsonapi:"attr,executionMode"`
 	Deleted          bool           `jsonapi:"attr,deleted"`
 	Vcs              *VcsEntity     `jsonapi:"relation,vcs,omitempty"`
+	Ssh              *SshEntity     `jsonapi:"relation,ssh,omitempty"`
 	Project          *ProjectEntity `jsonapi:"relation,project,omitempty"`
 	AllowRemoteApply bool           `jsonapi:"attr,allowRemoteApply"`
+	ModuleSshKey     *string        `jsonapi:"attr,moduleSshKey,omitempty"`
 }
 
 type WorkspaceTagEntity struct {

--- a/internal/provider/workspace_cli_resource.go
+++ b/internal/provider/workspace_cli_resource.go
@@ -41,6 +41,7 @@ type WorkspaceCliResourceModel struct {
 	IaCVersion     types.String `tfsdk:"iac_version"`
 	ExecutionMode  types.String `tfsdk:"execution_mode"`
 	ProjectId      types.String `tfsdk:"project_id"`
+	ModuleSshKey   types.String `tfsdk:"module_ssh_key"`
 }
 
 func NewWorkspaceCliResource() resource.Resource {
@@ -96,6 +97,12 @@ func (r *WorkspaceCliResource) Schema(ctx context.Context, req resource.SchemaRe
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
+			},
+			"module_ssh_key": schema.StringAttribute{
+				Optional: true,
+				Description: "SSH key ID (see terrakube_ssh) used to download private Terraform/OpenTofu modules " +
+					"referenced via git-based module sources within this workspace. Leave unset to leave any " +
+					"existing value untouched; set to an empty string to clear it.",
 			},
 		},
 	}
@@ -157,6 +164,10 @@ func (r *WorkspaceCliResource) Create(ctx context.Context, req resource.CreateRe
 		bodyRequest.Project = &client.ProjectEntity{ID: plan.ProjectId.ValueString()}
 	}
 
+	if !plan.ModuleSshKey.IsNull() {
+		bodyRequest.ModuleSshKey = plan.ModuleSshKey.ValueStringPointer()
+	}
+
 	var out = new(bytes.Buffer)
 	err := jsonapi.MarshalPayload(out, bodyRequest)
 
@@ -205,6 +216,7 @@ func (r *WorkspaceCliResource) Create(ctx context.Context, req resource.CreateRe
 	} else {
 		plan.ProjectId = types.StringNull()
 	}
+	plan.ModuleSshKey = types.StringPointerValue(newWorkspaceCli.ModuleSshKey)
 
 	tflog.Info(ctx, "Workspace Cli Resource Created", map[string]any{"success": true})
 
@@ -266,6 +278,7 @@ func (r *WorkspaceCliResource) Read(ctx context.Context, req resource.ReadReques
 	} else {
 		state.ProjectId = types.StringNull()
 	}
+	state.ModuleSshKey = types.StringPointerValue(workspace.ModuleSshKey)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
@@ -300,6 +313,10 @@ func (r *WorkspaceCliResource) Update(ctx context.Context, req resource.UpdateRe
 
 	if !plan.ProjectId.IsNull() && !plan.ProjectId.IsUnknown() {
 		bodyRequest.Project = &client.ProjectEntity{ID: plan.ProjectId.ValueString()}
+	}
+
+	if !plan.ModuleSshKey.IsNull() {
+		bodyRequest.ModuleSshKey = plan.ModuleSshKey.ValueStringPointer()
 	}
 
 	var out = new(bytes.Buffer)
@@ -371,6 +388,7 @@ func (r *WorkspaceCliResource) Update(ctx context.Context, req resource.UpdateRe
 	} else {
 		plan.ProjectId = types.StringNull()
 	}
+	plan.ModuleSshKey = types.StringPointerValue(workspace.ModuleSshKey)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }

--- a/internal/provider/workspace_data_source.go
+++ b/internal/provider/workspace_data_source.go
@@ -44,6 +44,8 @@ type WorkspaceDataSourceModel struct {
 	Deleted          types.Bool   `tfsdk:"deleted"`
 	AllowRemoteApply types.Bool   `tfsdk:"allowremoteapply"`
 	VCSID            types.String `tfsdk:"vcsid"`
+	SSHID            types.String `tfsdk:"sshid"`
+	ModuleSshKey     types.String `tfsdk:"module_ssh_key"`
 }
 
 func NewWorkspaceDataSource() datasource.DataSource {
@@ -152,6 +154,14 @@ func (d *WorkspaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				Description: "VCS ID",
 				Computed:    true,
 			},
+			"sshid": schema.StringAttribute{
+				Description: "SSH key ID used to clone the workspace repository directly over SSH",
+				Computed:    true,
+			},
+			"module_ssh_key": schema.StringAttribute{
+				Description: "SSH key ID used to download private Terraform/OpenTofu modules referenced via git-based module sources within this workspace",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -251,6 +261,10 @@ func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 		if data.Vcs != nil {
 			state.VCSID = types.StringValue(data.Vcs.ID)
 		}
+		if data.Ssh != nil {
+			state.SSHID = types.StringValue(data.Ssh.ID)
+		}
+		state.ModuleSshKey = types.StringPointerValue(data.ModuleSshKey)
 	}
 
 	diags := resp.State.Set(ctx, &state)

--- a/internal/provider/workspace_ssh_test.go
+++ b/internal/provider/workspace_ssh_test.go
@@ -1,0 +1,367 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// TestWorkspaceVcsResource_Create_SendsSshRelationship covers the primary
+// ask: a workspace can clone its own repository over raw SSH (as an
+// alternative to an OAuth-based vcs connection) by setting ssh_id, which
+// must be marshaled as the "ssh" relationship and round-tripped back into
+// state from the API response.
+func TestWorkspaceVcsResource_Create_SendsSshRelationship(t *testing.T) {
+	ctx := context.Background()
+	s, objType := workspaceVcsSchemaAndType(t, ctx)
+
+	const orgID = "org-1"
+
+	var capturedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/organization/"+orgID+"/workspace", func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		capturedBody = body
+		fmt.Fprint(w, `{"data":{"type":"workspace","id":"ws-created-1","attributes":{`+
+			`"name":"my-workspace","description":null,"source":"git@example.com:org/repo.git",`+
+			`"branch":"main","folder":"/","defaultTemplate":"tmpl-1","iacType":"terraform",`+
+			`"terraformVersion":"1.12.0","executionMode":"remote","allowRemoteApply":false},`+
+			`"relationships":{"project":{"data":null},"ssh":{"data":{"type":"ssh","id":"ssh-1"}}}}}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceVcsResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	planValue := buildObjectValue(objType, map[string]tftypes.Value{
+		"organization_id":    tftypes.NewValue(tftypes.String, orgID),
+		"name":               tftypes.NewValue(tftypes.String, "my-workspace"),
+		"repository":         tftypes.NewValue(tftypes.String, "git@example.com:org/repo.git"),
+		"template_id":        tftypes.NewValue(tftypes.String, "tmpl-1"),
+		"iac_version":        tftypes.NewValue(tftypes.String, "1.12.0"),
+		"branch":             tftypes.NewValue(tftypes.String, "main"),
+		"folder":             tftypes.NewValue(tftypes.String, "/"),
+		"iac_type":           tftypes.NewValue(tftypes.String, "terraform"),
+		"execution_mode":     tftypes.NewValue(tftypes.String, "remote"),
+		"allow_remote_apply": tftypes.NewValue(tftypes.Bool, false),
+		"ssh_id":             tftypes.NewValue(tftypes.String, "ssh-1"),
+		"project_id":         tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	})
+
+	req := resource.CreateRequest{Plan: tfsdk.Plan{Schema: s, Raw: planValue}}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	if !strings.Contains(string(capturedBody), `"ssh"`) {
+		t.Errorf("expected request body to include the ssh relationship, got: %s", capturedBody)
+	}
+	if !strings.Contains(string(capturedBody), `"id":"ssh-1"`) {
+		t.Errorf("expected request body to reference ssh key id ssh-1, got: %s", capturedBody)
+	}
+
+	var result WorkspaceVcsResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if result.SshId.ValueString() != "ssh-1" {
+		t.Errorf("expected ssh_id to be ssh-1 after create, got: %v", result.SshId)
+	}
+}
+
+// TestWorkspaceVcsResource_Update_ResolvesSshIdToNullWhenApiReturnsNoSsh
+// mirrors the existing project_id null-resolution coverage: if the API
+// reports no ssh relationship, SshId must be explicitly null rather than
+// left holding a stale prior value (Terraform's protocol rejects unknown
+// values after apply, and a stale value would cause permanent drift).
+func TestWorkspaceVcsResource_Update_ResolvesSshIdToNullWhenApiReturnsNoSsh(t *testing.T) {
+	ctx := context.Background()
+	s, objType := workspaceVcsSchemaAndType(t, ctx)
+
+	const (
+		orgID = "org-1"
+		wsID  = "ws-1"
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/organization/"+orgID+"/workspace/"+wsID, func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprint(w, `{"data":{"type":"workspace","id":"ws-1","attributes":{`+
+			`"name":"my-workspace","description":null,"source":"https://example.com/repo.git",`+
+			`"branch":"main","folder":"/","defaultTemplate":"tmpl-1","iacType":"terraform",`+
+			`"terraformVersion":"1.12.0","executionMode":"remote","allowRemoteApply":false},`+
+			`"relationships":{"project":{"data":null}}}}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceVcsResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	base := map[string]tftypes.Value{
+		"id":                 tftypes.NewValue(tftypes.String, wsID),
+		"organization_id":    tftypes.NewValue(tftypes.String, orgID),
+		"name":               tftypes.NewValue(tftypes.String, "my-workspace"),
+		"repository":         tftypes.NewValue(tftypes.String, "https://example.com/repo.git"),
+		"template_id":        tftypes.NewValue(tftypes.String, "tmpl-1"),
+		"iac_version":        tftypes.NewValue(tftypes.String, "1.12.0"),
+		"branch":             tftypes.NewValue(tftypes.String, "main"),
+		"folder":             tftypes.NewValue(tftypes.String, "/"),
+		"iac_type":           tftypes.NewValue(tftypes.String, "terraform"),
+		"execution_mode":     tftypes.NewValue(tftypes.String, "remote"),
+		"allow_remote_apply": tftypes.NewValue(tftypes.Bool, false),
+		"project_id":         tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	}
+
+	// Prior state had ssh_id set (e.g. the workspace was switched from an
+	// SSH-based source to a vcs connection); the new plan drops it.
+	stateOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		stateOverrides[k] = v
+	}
+	stateOverrides["ssh_id"] = tftypes.NewValue(tftypes.String, "old-ssh-key")
+
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range base {
+		planOverrides[k] = v
+	}
+	planOverrides["ssh_id"] = tftypes.NewValue(tftypes.String, nil)
+
+	req := resource.UpdateRequest{
+		State: tfsdk.State{Schema: s, Raw: buildObjectValue(objType, stateOverrides)},
+		Plan:  tfsdk.Plan{Schema: s, Raw: buildObjectValue(objType, planOverrides)},
+	}
+	resp := &resource.UpdateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Update(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Update returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	var result WorkspaceVcsResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if !result.SshId.IsNull() {
+		t.Errorf("expected ssh_id to be null after update since the API returned no ssh relationship, got: %v", result.SshId)
+	}
+}
+
+// TestWorkspaceVcsResource_Create_SendsModuleSshKeyAttribute covers the
+// second SSH mechanism: moduleSshKey is a plain attribute (not a
+// relationship) that controls which org SSH key is used to download
+// private Terraform/OpenTofu modules referenced via git-based module
+// sources, independent of how the workspace's own repo is cloned.
+func TestWorkspaceVcsResource_Create_SendsModuleSshKeyAttribute(t *testing.T) {
+	ctx := context.Background()
+	s, objType := workspaceVcsSchemaAndType(t, ctx)
+
+	const orgID = "org-1"
+
+	var capturedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/organization/"+orgID+"/workspace", func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		capturedBody = body
+		fmt.Fprint(w, `{"data":{"type":"workspace","id":"ws-created-1","attributes":{`+
+			`"name":"my-workspace","description":null,"source":"https://example.com/repo.git",`+
+			`"branch":"main","folder":"/","defaultTemplate":"tmpl-1","iacType":"terraform",`+
+			`"terraformVersion":"1.12.0","executionMode":"remote","allowRemoteApply":false,`+
+			`"moduleSshKey":"module-ssh-1"},`+
+			`"relationships":{"project":{"data":null}}}}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &WorkspaceVcsResource{
+		client:   server.Client(),
+		endpoint: server.URL,
+		token:    "test-token",
+	}
+
+	planValue := buildObjectValue(objType, map[string]tftypes.Value{
+		"organization_id":    tftypes.NewValue(tftypes.String, orgID),
+		"name":               tftypes.NewValue(tftypes.String, "my-workspace"),
+		"repository":         tftypes.NewValue(tftypes.String, "https://example.com/repo.git"),
+		"template_id":        tftypes.NewValue(tftypes.String, "tmpl-1"),
+		"iac_version":        tftypes.NewValue(tftypes.String, "1.12.0"),
+		"branch":             tftypes.NewValue(tftypes.String, "main"),
+		"folder":             tftypes.NewValue(tftypes.String, "/"),
+		"iac_type":           tftypes.NewValue(tftypes.String, "terraform"),
+		"execution_mode":     tftypes.NewValue(tftypes.String, "remote"),
+		"allow_remote_apply": tftypes.NewValue(tftypes.Bool, false),
+		"module_ssh_key":     tftypes.NewValue(tftypes.String, "module-ssh-1"),
+		"project_id":         tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	})
+
+	req := resource.CreateRequest{Plan: tfsdk.Plan{Schema: s, Raw: planValue}}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	if !strings.Contains(string(capturedBody), `"moduleSshKey":"module-ssh-1"`) {
+		t.Errorf("expected request body to include moduleSshKey attribute, got: %s", capturedBody)
+	}
+
+	var result WorkspaceVcsResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if result.ModuleSshKey.ValueString() != "module-ssh-1" {
+		t.Errorf("expected module_ssh_key to be module-ssh-1 after create, got: %v", result.ModuleSshKey)
+	}
+}
+
+// TestWorkspaceCliResource_Create_SendsModuleSshKeyAttribute covers the
+// same moduleSshKey attribute on CLI-driven workspaces, since private
+// module downloads are independent of whether the workspace itself is
+// VCS- or CLI-driven.
+func TestWorkspaceCliResource_Create_SendsModuleSshKeyAttribute(t *testing.T) {
+	ctx := context.Background()
+
+	r := &WorkspaceCliResource{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+	s := schemaResp.Schema
+	objType, ok := s.Type().TerraformType(ctx).(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected schema type to be a tftypes.Object")
+	}
+
+	const orgID = "org-1"
+
+	var capturedBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/organization/"+orgID+"/workspace", func(w http.ResponseWriter, req *http.Request) {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("reading request body: %v", err)
+		}
+		capturedBody = body
+		fmt.Fprint(w, `{"data":{"type":"workspace","id":"ws-created-1","attributes":{`+
+			`"name":"my-workspace","description":null,"iacType":"terraform",`+
+			`"terraformVersion":"1.12.0","executionMode":"remote","moduleSshKey":"module-ssh-2"},`+
+			`"relationships":{"project":{"data":null}}}}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r.client = server.Client()
+	r.endpoint = server.URL
+	r.token = "test-token"
+
+	planValue := buildObjectValue(objType, map[string]tftypes.Value{
+		"organization_id": tftypes.NewValue(tftypes.String, orgID),
+		"name":            tftypes.NewValue(tftypes.String, "my-workspace"),
+		"iac_version":     tftypes.NewValue(tftypes.String, "1.12.0"),
+		"iac_type":        tftypes.NewValue(tftypes.String, "terraform"),
+		"execution_mode":  tftypes.NewValue(tftypes.String, "remote"),
+		"module_ssh_key":  tftypes.NewValue(tftypes.String, "module-ssh-2"),
+		"project_id":      tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	})
+
+	req := resource.CreateRequest{Plan: tfsdk.Plan{Schema: s, Raw: planValue}}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: s}}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("Create returned diagnostics: %v", resp.Diagnostics)
+	}
+
+	if !strings.Contains(string(capturedBody), `"moduleSshKey":"module-ssh-2"`) {
+		t.Errorf("expected request body to include moduleSshKey attribute, got: %s", capturedBody)
+	}
+
+	var result WorkspaceCliResourceModel
+	if diags := resp.State.Get(ctx, &result); diags.HasError() {
+		t.Fatalf("reading resulting state: %v", diags)
+	}
+
+	if result.ModuleSshKey.ValueString() != "module-ssh-2" {
+		t.Errorf("expected module_ssh_key to be module-ssh-2 after create, got: %v", result.ModuleSshKey)
+	}
+}
+
+// TestWorkspaceVcsResource_VcsIdAndSshId_AreMutuallyExclusive exercises the
+// actual ConflictsWith validators wired onto vcs_id and ssh_id: a workspace
+// clones its source either via an OAuth vcs connection or a raw SSH key,
+// never both, so configuring both must fail validation.
+func TestWorkspaceVcsResource_VcsIdAndSshId_AreMutuallyExclusive(t *testing.T) {
+	ctx := context.Background()
+	s, objType := workspaceVcsSchemaAndType(t, ctx)
+
+	configValue := buildObjectValue(objType, map[string]tftypes.Value{
+		"organization_id": tftypes.NewValue(tftypes.String, "org-1"),
+		"name":            tftypes.NewValue(tftypes.String, "my-workspace"),
+		"repository":      tftypes.NewValue(tftypes.String, "https://example.com/repo.git"),
+		"template_id":     tftypes.NewValue(tftypes.String, "tmpl-1"),
+		"iac_version":     tftypes.NewValue(tftypes.String, "1.12.0"),
+		"vcs_id":          tftypes.NewValue(tftypes.String, "vcs-1"),
+		"ssh_id":          tftypes.NewValue(tftypes.String, "ssh-1"),
+	})
+	config := tfsdk.Config{Schema: s, Raw: configValue}
+
+	vcsIDAttr, ok := s.Attributes["vcs_id"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected vcs_id to be a StringAttribute")
+	}
+	if len(vcsIDAttr.Validators) == 0 {
+		t.Fatalf("expected vcs_id to carry a ConflictsWith validator against ssh_id")
+	}
+
+	resp := &validator.StringResponse{}
+	vcsIDAttr.Validators[0].ValidateString(ctx, validator.StringRequest{
+		Path:           path.Root("vcs_id"),
+		PathExpression: path.MatchRoot("vcs_id"),
+		Config:         config,
+		ConfigValue:    types.StringValue("vcs-1"),
+	}, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Error("expected setting both vcs_id and ssh_id to fail validation, but ConflictsWith reported no error")
+	}
+}

--- a/internal/provider/workspace_vcs_resource.go
+++ b/internal/provider/workspace_vcs_resource.go
@@ -49,8 +49,10 @@ type WorkspaceVcsResourceModel struct {
 	Folder           types.String `tfsdk:"folder"`
 	ExecutionMode    types.String `tfsdk:"execution_mode"`
 	VcsId            types.String `tfsdk:"vcs_id"`
+	SshId            types.String `tfsdk:"ssh_id"`
 	AllowRemoteApply types.Bool   `tfsdk:"allow_remote_apply"`
 	ProjectId        types.String `tfsdk:"project_id"`
+	ModuleSshKey     types.String `tfsdk:"module_ssh_key"`
 }
 
 func NewWorkspaceVcsResource() resource.Resource {
@@ -132,6 +134,25 @@ func (r *WorkspaceVcsResource) Schema(ctx context.Context, req resource.SchemaRe
 			"vcs_id": schema.StringAttribute{
 				Optional:    true,
 				Description: "VCS connection ID for private workspaces",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("ssh_id")),
+				},
+			},
+			"ssh_id": schema.StringAttribute{
+				Optional: true,
+				Description: "SSH key ID (see terrakube_ssh) used to clone the workspace repository directly over SSH " +
+					"(e.g. git@github.com:org/repo.git), as an alternative to an OAuth-based VCS connection. Mutually " +
+					"exclusive with vcs_id. Leave unset to leave any existing SSH key assignment untouched.",
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot("vcs_id")),
+				},
+			},
+			"module_ssh_key": schema.StringAttribute{
+				Optional: true,
+				Description: "SSH key ID (see terrakube_ssh) used to download private Terraform/OpenTofu modules " +
+					"referenced via git-based module sources within this workspace. This key is not used to clone " +
+					"the workspace repository itself; use vcs_id or ssh_id for that. Leave unset to leave any " +
+					"existing value untouched; set to an empty string to clear it.",
 			},
 			"allow_remote_apply": schema.BoolAttribute{
 				Optional:    true,
@@ -211,6 +232,15 @@ func (r *WorkspaceVcsResource) Create(ctx context.Context, req resource.CreateRe
 		bodyRequest.Vcs = &client.VcsEntity{ID: plan.VcsId.ValueString()}
 	}
 
+	if !plan.SshId.IsNull() {
+		tflog.Info(ctx, fmt.Sprintf("Workspace using Ssh key id: %s", plan.SshId.ValueString()))
+		bodyRequest.Ssh = &client.SshEntity{ID: plan.SshId.ValueString()}
+	}
+
+	if !plan.ModuleSshKey.IsNull() {
+		bodyRequest.ModuleSshKey = plan.ModuleSshKey.ValueStringPointer()
+	}
+
 	if !plan.ProjectId.IsNull() && !plan.ProjectId.IsUnknown() {
 		bodyRequest.Project = &client.ProjectEntity{ID: plan.ProjectId.ValueString()}
 	}
@@ -273,6 +303,14 @@ func (r *WorkspaceVcsResource) Create(ctx context.Context, req resource.CreateRe
 	if !plan.VcsId.IsNull() {
 		plan.VcsId = types.StringValue(newWorkspaceVcs.Vcs.ID)
 	}
+
+	if newWorkspaceVcs.Ssh != nil {
+		plan.SshId = types.StringValue(newWorkspaceVcs.Ssh.ID)
+	} else {
+		plan.SshId = types.StringNull()
+	}
+
+	plan.ModuleSshKey = types.StringPointerValue(newWorkspaceVcs.ModuleSshKey)
 
 	if !plan.Folder.IsNull() {
 		plan.Folder = types.StringValue(newWorkspaceVcs.Folder)
@@ -343,6 +381,14 @@ func (r *WorkspaceVcsResource) Read(ctx context.Context, req resource.ReadReques
 		state.VcsId = types.StringValue(workspace.Vcs.ID)
 	}
 
+	if workspace.Ssh != nil {
+		state.SshId = types.StringValue(workspace.Ssh.ID)
+	} else {
+		state.SshId = types.StringNull()
+	}
+
+	state.ModuleSshKey = types.StringPointerValue(workspace.ModuleSshKey)
+
 	if workspace.Project != nil {
 		state.ProjectId = types.StringValue(workspace.Project.ID)
 	} else {
@@ -386,6 +432,15 @@ func (r *WorkspaceVcsResource) Update(ctx context.Context, req resource.UpdateRe
 	if !plan.VcsId.IsNull() {
 		tflog.Info(ctx, fmt.Sprintf("Workspace using Vcs connection id: %s", plan.VcsId.ValueString()))
 		bodyRequest.Vcs = &client.VcsEntity{ID: plan.VcsId.ValueString()}
+	}
+
+	if !plan.SshId.IsNull() {
+		tflog.Info(ctx, fmt.Sprintf("Workspace using Ssh key id: %s", plan.SshId.ValueString()))
+		bodyRequest.Ssh = &client.SshEntity{ID: plan.SshId.ValueString()}
+	}
+
+	if !plan.ModuleSshKey.IsNull() {
+		bodyRequest.ModuleSshKey = plan.ModuleSshKey.ValueStringPointer()
 	}
 
 	if !plan.ProjectId.IsNull() && !plan.ProjectId.IsUnknown() {
@@ -464,6 +519,12 @@ func (r *WorkspaceVcsResource) Update(ctx context.Context, req resource.UpdateRe
 	if workspace.Vcs != nil {
 		plan.VcsId = types.StringValue(workspace.Vcs.ID)
 	}
+	if workspace.Ssh != nil {
+		plan.SshId = types.StringValue(workspace.Ssh.ID)
+	} else {
+		plan.SshId = types.StringNull()
+	}
+	plan.ModuleSshKey = types.StringPointerValue(workspace.ModuleSshKey)
 	if workspace.Project != nil {
 		plan.ProjectId = types.StringValue(workspace.Project.ID)
 	} else {


### PR DESCRIPTION
## Summary

- Add `ssh_id` to `terrakube_workspace_vcs`, letting a workspace clone its own repository directly over SSH (`git@host:org/repo.git`) using a `terrakube_ssh` key, as an alternative to an OAuth-based `vcs_id` connection — mutually exclusive with `vcs_id`, enforced via a `ConflictsWith` validator.
- Add `module_ssh_key` to both `terrakube_workspace_vcs` and `terrakube_workspace_cli`, for downloading private Terraform/OpenTofu modules referenced via git-based module sources. This is independent of the workspace's own repo checkout and applies regardless of whether the workspace is VCS- or CLI-driven.
- Surface both `sshid` and `module_ssh_key` as computed fields on the `terrakube_workspace` data source.
- Extend `client.WorkspaceEntity` with the `ssh` relationship and `moduleSshKey` attribute to match the backend's `Workspace` entity.

## Why

The provider had no way to configure SSH access for workspaces at all, despite the backend (`terrakube-io/terrakube`) supporting two distinct SSH mechanisms on the `workspace` entity: a `ssh` relationship for cloning the workspace's own source over SSH, and a separate `moduleSshKey` attribute for private module downloads. Neither was exposed.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (existing suite + 5 new tests in `workspace_ssh_test.go`: SSH relationship marshaling/round-trip on create, null-resolution on update, `module_ssh_key` round-trip on both VCS and CLI resources, and the `ConflictsWith` validator actually firing when both `vcs_id` and `ssh_id` are set)
- [x] Regenerated `docs/` via `tfplugindocs` (`go generate ./...`)
- [x] Updated `examples/resources/terrakube_workspace_vcs` and `terrakube_workspace_cli` with usage examples for both new fields