### PR TITLE
fix: return diagnostics instead of crashing when API is unreachable

### DIFF
--- a/internal/provider/organization_tag_data_source.go
+++ b/internal/provider/organization_tag_data_source.go
@@ -110,7 +110,8 @@ func (d *OrganizationTagDataSource) Read(ctx context.Context, req datasource.Rea
 
 	resOrgTag, err := d.client.Do(reqOrgTag)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing organization tag datasource request, error: %s, response status: %s", err, resOrgTag.Status))
+		resp.Diagnostics.AddError("Error executing organization tag datasource request", fmt.Sprintf("Error executing organization tag datasource request: %s", err))
+		return
 	}
 
 	body, err := io.ReadAll(resOrgTag.Body)

--- a/internal/provider/organization_template_data_source.go
+++ b/internal/provider/organization_template_data_source.go
@@ -112,7 +112,8 @@ func (d *OrganizationTemplateDataSource) Read(ctx context.Context, req datasourc
 
 	resTemplate, err := d.client.Do(reqTemplate)
 	if err != nil {
-		tflog.Error(ctx, "Error executing organization template datasource request")
+		resp.Diagnostics.AddError("Error executing organization template datasource request", fmt.Sprintf("Error executing organization template datasource request: %s", err))
+		return
 	}
 
 	body, err := io.ReadAll(resTemplate.Body)

--- a/internal/provider/output_data_source.go
+++ b/internal/provider/output_data_source.go
@@ -163,7 +163,7 @@ func (d *OutputDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	resFile, err := d.client.Do(reqFile)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Output datasource request part 4: %s", err))
+		resp.Diagnostics.AddError("Error executing Output datasource request part 4", fmt.Sprintf("Error executing Output datasource request part 4: %s", err))
 		return
 	}
 
@@ -440,7 +440,7 @@ func (d *OutputDataSource) ReadDataFromApi(url string, ctx context.Context, resp
 
 	resApi, err := d.client.Do(regApi)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Output datasource request: %s", err))
+		resp.Diagnostics.AddError("Error executing Output datasource request", fmt.Sprintf("Error executing Output datasource request: %s", err))
 		return
 	}
 

--- a/internal/provider/project_data_source.go
+++ b/internal/provider/project_data_source.go
@@ -153,7 +153,7 @@ func (d *ProjectDataSource) ReadDataFromApi(url string, ctx context.Context, res
 
 	resApi, err := d.client.Do(regApi)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Project datasource request: %s", err))
+		resp.Diagnostics.AddError("Error executing Project datasource request", fmt.Sprintf("Error executing Project datasource request: %s", err))
 		return
 	}
 

--- a/internal/provider/team_data_source.go
+++ b/internal/provider/team_data_source.go
@@ -188,7 +188,7 @@ func (d *TeamDataSource) ReadDataFromApi(url string, ctx context.Context, resp *
 
 	resApi, err := d.client.Do(regApi)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Team datasource request: %s", err))
+		resp.Diagnostics.AddError("Error executing Team datasource request", fmt.Sprintf("Error executing Team datasource request: %s", err))
 		return
 	}
 

--- a/internal/provider/workspace_data_source.go
+++ b/internal/provider/workspace_data_source.go
@@ -180,7 +180,7 @@ func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	resOrg, err := d.client.Do(reqOrg)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Workspace datasource request: %s", err))
+		resp.Diagnostics.AddError("Error executing Workspace datasource request", fmt.Sprintf("Error executing Workspace datasource request: %s", err))
 		return
 	}
 
@@ -221,7 +221,7 @@ func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	resWS, err := d.client.Do(reqWS)
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error executing Workspace datasource request part 2: %s", err))
+		resp.Diagnostics.AddError("Error executing Workspace datasource request part 2", fmt.Sprintf("Error executing Workspace datasource request part 2: %s", err))
 		return
 	}
 


### PR DESCRIPTION
Fixes #127

When the configured endpoint cannot be reached, several data sources logged the transport error and continued with a nil response, then dereferenced it (reading .Body, or .Status inside the log message itself), crashing the plugin with 'Plugin did not respond'.

This returns a proper diagnostic and stops on request execution errors in all eight affected sites (organization tag, organization template, output, project, team and workspace data sources).

Verified with a dev-override plan against an unreachable endpoint: before, the plugin crashes with 'Plugin did not respond'; after, the plan fails cleanly with 'Error executing organization tag datasource request: dial tcp 127.0.0.1:9: connect: connection refused'. go build and go vet clean.

Note: there is a related lower-severity pattern (Header.Add called before the http.NewRequest error check) in ~25 files that only crashes on malformed URLs. Left out to keep this focused, happy to do a follow-up if wanted.