### PR TITLE
fix: check http.NewRequest errors before using the request

### DIFF
--- a/internal/provider/collection_item_resource.go
+++ b/internal/provider/collection_item_resource.go
@@ -162,12 +162,12 @@ func (r *CollectionItemResource) Create(ctx context.Context, req resource.Create
 	}
 
 	collectionItemRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s/item", r.endpoint, plan.OrganizationId.ValueString(), plan.CollectionId.ValueString()), strings.NewReader(out.String()))
-	collectionItemRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionItemRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection item resource request", fmt.Sprintf("Error creating collection item resource request: %s", err))
 		return
 	}
+	collectionItemRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionItemRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionItemResponse, err := r.client.Do(collectionItemRequest)
 	if err != nil {
@@ -219,12 +219,12 @@ func (r *CollectionItemResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	collectionItemRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s/item/%s", r.endpoint, state.OrganizationId.ValueString(), state.CollectionId.ValueString(), state.ID.ValueString()), nil)
-	collectionItemRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionItemRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection resource request", fmt.Sprintf("Error creating collection item resource request: %s", err))
 		return
 	}
+	collectionItemRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionItemRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionItemResponse, err := r.client.Do(collectionItemRequest)
 	if err != nil {
@@ -261,12 +261,12 @@ func (r *CollectionItemResource) Read(ctx context.Context, req resource.ReadRequ
 			tflog.Debug(ctx, "this might be a known issue where the variable is removed in the gui and added back manually with the same key but a different id")
 			//lets query on key to see if we can find it
 			collectionItemRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s/item?filter[item]=key==%s", r.endpoint, state.OrganizationId.ValueString(), state.CollectionId.ValueString(), state.Key.ValueString()), nil)
-			collectionItemRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-			collectionItemRequest.Header.Add("Content-Type", "application/vnd.api+json")
 			if err != nil {
 				resp.Diagnostics.AddError("Error creating collection resource request", fmt.Sprintf("Error creating collection item resource request: %s", err))
 				return
 			}
+			collectionItemRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+			collectionItemRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 			collectionItemResponse, err := r.client.Do(collectionItemRequest)
 			if err != nil {
@@ -353,12 +353,12 @@ func (r *CollectionItemResource) Update(ctx context.Context, req resource.Update
 	}
 
 	collectionItemReq, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s/item/%s", r.endpoint, state.OrganizationId.ValueString(), state.CollectionId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	collectionItemReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionItemReq.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection item resource request", fmt.Sprintf("Error creating collection item resource request: %s", err))
 		return
 	}
+	collectionItemReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionItemReq.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionItemResponse, err := r.client.Do(collectionItemReq)
 	if err != nil {
@@ -374,12 +374,12 @@ func (r *CollectionItemResource) Update(ctx context.Context, req resource.Update
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	collectionItemReq, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s/item/%s", r.endpoint, state.OrganizationId.ValueString(), state.CollectionId.ValueString(), state.ID.ValueString()), nil)
-	collectionItemReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionItemReq.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection item resource request", fmt.Sprintf("Error creating collection item resource request: %s", err))
 		return
 	}
+	collectionItemReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionItemReq.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionItemResponse, err = r.client.Do(collectionItemReq)
 	if err != nil {
@@ -431,11 +431,11 @@ func (r *CollectionItemResource) Delete(ctx context.Context, req resource.Delete
 	}
 
 	workspaceRequest, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s/item/%s", r.endpoint, data.OrganizationId.ValueString(), data.CollectionId.ValueString(), data.ID.ValueString()), nil)
-	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection item resource request", fmt.Sprintf("Error creating collection item resource request: %s", err))
 		return
 	}
+	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(workspaceRequest)
 	if err != nil {

--- a/internal/provider/collection_reference_resource.go
+++ b/internal/provider/collection_reference_resource.go
@@ -136,12 +136,12 @@ func (r *CollectionReferenceResource) Create(ctx context.Context, req resource.C
 	}
 
 	collectionReferenceRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s/reference", r.endpoint, plan.OrganizationId.ValueString(), plan.CollectionId.ValueString()), strings.NewReader(out.String()))
-	collectionReferenceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionReferenceRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection reference resource request", fmt.Sprintf("Error creating collection reference resource request: %s", err))
 		return
 	}
+	collectionReferenceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionReferenceRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionReferenceResponse, err := r.client.Do(collectionReferenceRequest)
 	if err != nil {
@@ -191,12 +191,12 @@ func (r *CollectionReferenceResource) Read(ctx context.Context, req resource.Rea
 	}
 
 	collectionItemRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/reference/%s", r.endpoint, state.ID.ValueString()), nil)
-	collectionItemRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionItemRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection reference resource request", fmt.Sprintf("Error creating collection reference resource request: %s", err))
 		return
 	}
+	collectionItemRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionItemRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionReferenceResponse, err := r.client.Do(collectionItemRequest)
 	if err != nil {
@@ -275,12 +275,12 @@ func (r *CollectionReferenceResource) Update(ctx context.Context, req resource.U
 	}
 
 	collectionReferenceReq, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/reference/%s", r.endpoint, state.ID.ValueString()), strings.NewReader(out.String()))
-	collectionReferenceReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionReferenceReq.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection reference resource request", fmt.Sprintf("Error creating collection reference resource request: %s", err))
 		return
 	}
+	collectionReferenceReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionReferenceReq.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionReferenceResponse, err := r.client.Do(collectionReferenceReq)
 	if err != nil {
@@ -296,12 +296,12 @@ func (r *CollectionReferenceResource) Update(ctx context.Context, req resource.U
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	collectionReferenceReq, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/reference/%s", r.endpoint, state.ID.ValueString()), nil)
-	collectionReferenceReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionReferenceReq.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection reference resource request", fmt.Sprintf("Error creating collection reference resource request: %s", err))
 		return
 	}
+	collectionReferenceReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionReferenceReq.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionReferenceResponse, err = r.client.Do(collectionReferenceReq)
 	if err != nil {
@@ -351,11 +351,11 @@ func (r *CollectionReferenceResource) Delete(ctx context.Context, req resource.D
 	}
 
 	workspaceRequest, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/reference/%s", r.endpoint, data.ID.ValueString()), nil)
-	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection reference resource request", fmt.Sprintf("Error creating collection reference resource request: %s", err))
 		return
 	}
+	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(workspaceRequest)
 	if err != nil {

--- a/internal/provider/module_resource.go
+++ b/internal/provider/module_resource.go
@@ -184,12 +184,12 @@ func (r *ModuleResource) Create(ctx context.Context, req resource.CreateRequest,
 	tflog.Info(ctx, fmt.Sprintf("Body Request: %s", out.String()))
 
 	moduleRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/module", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	moduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	moduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating module resource request", fmt.Sprintf("Error creating team resource request: %s", err))
 		return
 	}
+	moduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	moduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	moduleResponse, err := r.client.Do(moduleRequest)
 	if err != nil {
@@ -243,12 +243,12 @@ func (r *ModuleResource) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	moduleRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/module/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	moduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	moduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating module resource request", fmt.Sprintf("Error creating team resource request: %s", err))
 		return
 	}
+	moduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	moduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	moduleResponse, err := r.client.Do(moduleRequest)
 	if err != nil {
@@ -356,12 +356,12 @@ func (r *ModuleResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	moduleRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/module/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	moduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	moduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating module resource request", fmt.Sprintf("Error creating team resource request: %s", err))
 		return
 	}
+	moduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	moduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	teamResponse, err := r.client.Do(moduleRequest)
 	if err != nil {
@@ -377,12 +377,12 @@ func (r *ModuleResource) Update(ctx context.Context, req resource.UpdateRequest,
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	moduleRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/module/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	moduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	moduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating module resource request", fmt.Sprintf("Error creating team resource request: %s", err))
 		return
 	}
+	moduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	moduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	teamResponse, err = r.client.Do(moduleRequest)
 	if err != nil {
@@ -429,11 +429,11 @@ func (r *ModuleResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	}
 
 	reqOrg, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/module/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), nil)
-	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating module resource request", fmt.Sprintf("Error creating team resource request: %s", err))
 		return
 	}
+	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(reqOrg)
 	if err != nil {

--- a/internal/provider/module_self_hosted_agent.go
+++ b/internal/provider/module_self_hosted_agent.go
@@ -138,12 +138,12 @@ func (r *AgentResource) Create(ctx context.Context, req resource.CreateRequest, 
 	tflog.Info(ctx, fmt.Sprintf("Body Request: %s", out.String()))
 
 	agentRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/agent", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	agentRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	agentRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating self hosted agent resource request", fmt.Sprintf("Error creating self hosted agent resource request: %s", err))
 		return
 	}
+	agentRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	agentRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	agentResponse, err := r.client.Do(agentRequest)
 	if err != nil {
@@ -188,12 +188,12 @@ func (r *AgentResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	agentRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/agent/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	agentRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	agentRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating self hosted agent resource request", fmt.Sprintf("Error creating self hosted agent resource request: %s", err))
 		return
 	}
+	agentRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	agentRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	agentResponse, err := r.client.Do(agentRequest)
 	if err != nil {
@@ -257,12 +257,12 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	agentRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/agent/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	agentRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	agentRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating self hosted agent resource request", fmt.Sprintf("Error creating self hosted agent resource request: %s", err))
 		return
 	}
+	agentRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	agentRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	agentResponse, err := r.client.Do(agentRequest)
 	if err != nil {
@@ -278,12 +278,12 @@ func (r *AgentResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	agentRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/agent/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	agentRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	agentRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating self hosted agent resource request", fmt.Sprintf("Error creating self hosted agent resource request: %s", err))
 		return
 	}
+	agentRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	agentRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	agentResponse, err = r.client.Do(agentRequest)
 	if err != nil {
@@ -324,11 +324,11 @@ func (r *AgentResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	}
 
 	reqOrg, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/agent/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), nil)
-	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating self hosted agent resource request", fmt.Sprintf("Error creating self hosted agent resource request: %s", err))
 		return
 	}
+	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(reqOrg)
 	if err != nil {

--- a/internal/provider/organization_collection_resource.go
+++ b/internal/provider/organization_collection_resource.go
@@ -142,12 +142,12 @@ func (r *CollectionResource) Create(ctx context.Context, req resource.CreateRequ
 	tflog.Info(ctx, "Body Response", map[string]any{"bodyResponse": strings.NewReader(out.String())})
 
 	collectionRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/collection", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	collectionRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection resource request", fmt.Sprintf("Error creating collection resource request: %s", err))
 		return
 	}
+	collectionRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionResponse, err := r.client.Do(collectionRequest)
 	if err != nil {
@@ -190,12 +190,12 @@ func (r *CollectionResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	collectionRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	collectionRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection resource request", fmt.Sprintf("Error creating collection resource request: %s", err))
 		return
 	}
+	collectionRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionResponse, err := r.client.Do(collectionRequest)
 	if err != nil {
@@ -265,12 +265,12 @@ func (r *CollectionResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	collectionRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	collectionRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection resource request", fmt.Sprintf("Error creating collection resource request: %s", err))
 		return
 	}
+	collectionRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionResponse, err := r.client.Do(collectionRequest)
 	if err != nil {
@@ -286,12 +286,12 @@ func (r *CollectionResource) Update(ctx context.Context, req resource.UpdateRequ
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	collectionRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	collectionRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	collectionRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection resource request", fmt.Sprintf("Error creating collection resource request: %s", err))
 		return
 	}
+	collectionRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	collectionRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	collectionResponse, err = r.client.Do(collectionRequest)
 	if err != nil {
@@ -333,11 +333,11 @@ func (r *CollectionResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	reqOrg, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/collection/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), nil)
-	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating collection resource request", fmt.Sprintf("Error creating collection resource request: %s", err))
 		return
 	}
+	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(reqOrg)
 	if err != nil {

--- a/internal/provider/organization_data_source.go
+++ b/internal/provider/organization_data_source.go
@@ -112,11 +112,12 @@ func (d *OrganizationDataSource) Read(ctx context.Context, req datasource.ReadRe
 	req.Config.Get(ctx, &state)
 
 	reqOrg, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization?filter[organization]=name==%s", d.endpoint, state.Name.ValueString()), nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating organization datasource request", fmt.Sprintf("Error creating organization datasource request: %s", err))
+		return
+	}
 	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	reqOrg.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, "Error creating organization datasource request")
-	}
 
 	resOrg, err := d.client.Do(reqOrg)
 	if err != nil {

--- a/internal/provider/organization_resource.go
+++ b/internal/provider/organization_resource.go
@@ -139,12 +139,12 @@ func (r *OrganizationResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	organizationRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization", r.endpoint), strings.NewReader(out.String()))
-	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization resource request", fmt.Sprintf("Error creating organization resource request: %s", err))
 		return
 	}
+	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationResponse, err := r.client.Do(organizationRequest)
 	if err != nil {
@@ -189,12 +189,12 @@ func (r *OrganizationResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	organizationRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s", r.endpoint, state.ID.ValueString()), nil)
-	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization resource request", fmt.Sprintf("Error creating organization resource request: %s", err))
 		return
 	}
+	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationResponse, err := r.client.Do(organizationRequest)
 	if err != nil {
@@ -267,12 +267,12 @@ func (r *OrganizationResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	organizationRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s", r.endpoint, state.ID.ValueString()), strings.NewReader(out.String()))
-	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization resource request", fmt.Sprintf("Error creating organization resource request: %s", err))
 		return
 	}
+	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationResponse, err := r.client.Do(organizationRequest)
 	if err != nil {
@@ -288,12 +288,12 @@ func (r *OrganizationResource) Update(ctx context.Context, req resource.UpdateRe
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	organizationRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s", r.endpoint, state.ID.ValueString()), nil)
-	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization resource request", fmt.Sprintf("Error creating organization resource request: %s", err))
 		return
 	}
+	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationResponse, err = r.client.Do(organizationRequest)
 	if err != nil {
@@ -372,12 +372,12 @@ func (r *OrganizationResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	reqOrg, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s", r.endpoint, data.ID.ValueString()), strings.NewReader(out.String()))
-	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	reqOrg.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization resource request", fmt.Sprintf("Error creating organization resource request: %s", err))
 		return
 	}
+	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	reqOrg.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationResponse, err := r.client.Do(reqOrg)
 	if err != nil {

--- a/internal/provider/organization_tag_data_source.go
+++ b/internal/provider/organization_tag_data_source.go
@@ -102,11 +102,12 @@ func (d *OrganizationTagDataSource) Read(ctx context.Context, req datasource.Rea
 	req.Config.Get(ctx, &state)
 
 	reqOrgTag, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/tag?filter[tag]=name==%s", d.endpoint, state.OrganizationId.ValueString(), state.Name.ValueString()), nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating organization tag datasource request", fmt.Sprintf("Error creating organization tag datasource request: %s", err))
+		return
+	}
 	reqOrgTag.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	reqOrgTag.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error creating organization tag datasource request, error: %s", err))
-	}
 
 	resOrgTag, err := d.client.Do(reqOrgTag)
 	if err != nil {

--- a/internal/provider/organization_tag_resource.go
+++ b/internal/provider/organization_tag_resource.go
@@ -124,12 +124,12 @@ func (r *OrganizationTagResource) Create(ctx context.Context, req resource.Creat
 	}
 
 	organizationTagRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/tag", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	organizationTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization tag resource request", fmt.Sprintf("Error creating organization tag resource request: %s", err))
 		return
 	}
+	organizationTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationTagResponse, err := r.client.Do(organizationTagRequest)
 	if err != nil {
@@ -169,12 +169,12 @@ func (r *OrganizationTagResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	organizationTagRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/tag/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	organizationTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization tag resource request", fmt.Sprintf("Error creating organization tag resource request: %s", err))
 		return
 	}
+	organizationTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationTagResponse, err := r.client.Do(organizationTagRequest)
 	if err != nil {
@@ -240,12 +240,12 @@ func (r *OrganizationTagResource) Update(ctx context.Context, req resource.Updat
 	}
 
 	organizationTagRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/tag/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	organizationTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization tag resource request", fmt.Sprintf("Error creating organization tag resource request: %s", err))
 		return
 	}
+	organizationTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationTagResponse, err := r.client.Do(organizationTagRequest)
 	if err != nil {
@@ -261,12 +261,12 @@ func (r *OrganizationTagResource) Update(ctx context.Context, req resource.Updat
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	organizationTagRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/tag/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	organizationTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization tag resource request", fmt.Sprintf("Error creating organization tag resource request: %s", err))
 		return
 	}
+	organizationTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationTagResponse, err = r.client.Do(organizationTagRequest)
 	if err != nil {
@@ -306,11 +306,11 @@ func (r *OrganizationTagResource) Delete(ctx context.Context, req resource.Delet
 	}
 
 	reqOrg, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/tag/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), nil)
-	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization tag resource request", fmt.Sprintf("Error creating organization tag resource request: %s", err))
 		return
 	}
+	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	organizationTagResponse, err := r.client.Do(reqOrg)
 	if err != nil {

--- a/internal/provider/organization_template_data_source.go
+++ b/internal/provider/organization_template_data_source.go
@@ -104,11 +104,12 @@ func (d *OrganizationTemplateDataSource) Read(ctx context.Context, req datasourc
 
 	apiUrl := fmt.Sprintf("%s/api/v1/organization/%s/template?filter[template]=name=='%s'", d.endpoint, state.OrganizationId.ValueString(), url.PathEscape(state.Name.ValueString()))
 	reqTemplate, err := http.NewRequest(http.MethodGet, apiUrl, nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating organization template datasource request", fmt.Sprintf("Error creating organization template datasource request: %s", err))
+		return
+	}
 	reqTemplate.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	reqTemplate.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, "Error creating organization template datasource request")
-	}
 
 	resTemplate, err := d.client.Do(reqTemplate)
 	if err != nil {

--- a/internal/provider/organization_template_resource.go
+++ b/internal/provider/organization_template_resource.go
@@ -145,12 +145,12 @@ func (r *OrganizationTemplateResource) Create(ctx context.Context, req resource.
 	}
 
 	organizationTemplateRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/template", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationTemplateRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization template resource request", fmt.Sprintf("Error creating organization template resource request: %s", err))
 		return
 	}
+	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationTemplateRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationTemplateResponse, err := r.client.Do(organizationTemplateRequest)
 	if err != nil {
@@ -198,12 +198,12 @@ func (r *OrganizationTemplateResource) Read(ctx context.Context, req resource.Re
 	}
 
 	organizationTemplateRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/template/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationTemplateRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization template resource request", fmt.Sprintf("Error creating organization template resource request: %s", err))
 		return
 	}
+	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationTemplateRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationTemplateResponse, err := r.client.Do(organizationTemplateRequest)
 	if err != nil {
@@ -283,12 +283,12 @@ func (r *OrganizationTemplateResource) Update(ctx context.Context, req resource.
 	tflog.Info(ctx, "Body Update Request: "+out.String())
 
 	organizationTemplateRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/template/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationTemplateRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization template resource request", fmt.Sprintf("Error creating organization template resource request: %s", err))
 		return
 	}
+	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationTemplateRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationTemplateResponse, err := r.client.Do(organizationTemplateRequest)
 	if err != nil {
@@ -304,12 +304,12 @@ func (r *OrganizationTemplateResource) Update(ctx context.Context, req resource.
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	organizationTemplateRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/template/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationTemplateRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization template resource request", fmt.Sprintf("Error creating organization template resource request: %s", err))
 		return
 	}
+	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationTemplateRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationTemplateResponse, err = r.client.Do(organizationTemplateRequest)
 	if err != nil {
@@ -357,11 +357,11 @@ func (r *OrganizationTemplateResource) Delete(ctx context.Context, req resource.
 	}
 
 	organizationTemplateRequest, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/template/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), nil)
-	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization template resource request", fmt.Sprintf("Error creating organization template resource request: %s", err))
 		return
 	}
+	organizationTemplateRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	organizationTemplateResponse, err := r.client.Do(organizationTemplateRequest)
 	if err != nil {

--- a/internal/provider/organization_variable_resource.go
+++ b/internal/provider/organization_variable_resource.go
@@ -155,12 +155,12 @@ func (r *OrganizationVariableResource) Create(ctx context.Context, req resource.
 	}
 
 	organizationVarRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/globalvar", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization variable resource request", fmt.Sprintf("Error creating organization variable resource request: %s", err))
 		return
 	}
+	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationVarResponse, err := r.client.Do(organizationVarRequest)
 	if err != nil {
@@ -212,12 +212,12 @@ func (r *OrganizationVariableResource) Read(ctx context.Context, req resource.Re
 	}
 
 	organizationVarRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/globalvar/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization variable resource request", fmt.Sprintf("Error creating organization variable resource request: %s", err))
 		return
 	}
+	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationVariableResponse, err := r.client.Do(organizationVarRequest)
 	if err != nil {
@@ -302,12 +302,12 @@ func (r *OrganizationVariableResource) Update(ctx context.Context, req resource.
 	tflog.Info(ctx, "Body Update Request: "+out.String())
 
 	organizationVarRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/globalvar/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization variable resource request", fmt.Sprintf("Error creating organization variable resource request: %s", err))
 		return
 	}
+	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationVarResponse, err := r.client.Do(organizationVarRequest)
 	if err != nil {
@@ -323,12 +323,12 @@ func (r *OrganizationVariableResource) Update(ctx context.Context, req resource.
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	organizationVarRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/globalvar/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization variable resource request", fmt.Sprintf("Error creating organization variable resource request: %s", err))
 		return
 	}
+	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationVarResponse, err = r.client.Do(organizationVarRequest)
 	if err != nil {
@@ -381,11 +381,11 @@ func (r *OrganizationVariableResource) Delete(ctx context.Context, req resource.
 	}
 
 	organizationVarRequest, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/globalvar/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), nil)
-	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating organization variable resource request", fmt.Sprintf("Error creating organization variable resource request: %s", err))
 		return
 	}
+	organizationVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(organizationVarRequest)
 	if err != nil {

--- a/internal/provider/output_data_source.go
+++ b/internal/provider/output_data_source.go
@@ -155,11 +155,12 @@ func (d *OutputDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	//Output contains a link to the Output.json file, which contains the real data we need.
 	OutputUrl := data.Output
 	reqFile, err := http.NewRequest(http.MethodGet, OutputUrl, nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating request", fmt.Sprintf("Error creating request: %s", err))
+		return
+	}
 	reqFile.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	reqFile.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("Error creating Output datasource request for output json file failed (%s)", OutputUrl))
-	}
 
 	resFile, err := d.client.Do(reqFile)
 	if err != nil {
@@ -432,11 +433,12 @@ func inferAttrType(raw interface{}) (attr.Type, error) {
 
 func (d *OutputDataSource) ReadDataFromApi(url string, ctx context.Context, resp *datasource.ReadResponse, structType any) (data []interface{}) {
 	regApi, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating Output datasource request", fmt.Sprintf("Error creating Output datasource request: %s", err))
+		return
+	}
 	regApi.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	regApi.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, "Error creating Output datasource request")
-	}
 
 	resApi, err := d.client.Do(regApi)
 	if err != nil {

--- a/internal/provider/project_data_source.go
+++ b/internal/provider/project_data_source.go
@@ -145,11 +145,12 @@ func (d *ProjectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 func (d *ProjectDataSource) ReadDataFromApi(url string, ctx context.Context, resp *datasource.ReadResponse, structType any) (data []interface{}) {
 	regApi, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating Project datasource request", fmt.Sprintf("Error creating Project datasource request: %s", err))
+		return
+	}
 	regApi.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	regApi.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, "Error creating Project datasource request")
-	}
 
 	resApi, err := d.client.Do(regApi)
 	if err != nil {

--- a/internal/provider/ssh_data_source.go
+++ b/internal/provider/ssh_data_source.go
@@ -103,11 +103,12 @@ func (d *SshDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	req.Config.Get(ctx, &state)
 
 	requestSsh, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/ssh?filter[ssh]=name==%s", d.endpoint, state.OrganizationId.ValueString(), state.Name.ValueString()), nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating ssh datasource request", fmt.Sprintf("Error creating ssh datasource request: %s", err))
+		return
+	}
 	requestSsh.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	requestSsh.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, "Error creating ssh datasource request")
-	}
 
 	responseSsh, err := d.client.Do(requestSsh)
 	if err != nil {

--- a/internal/provider/ssh_resource.go
+++ b/internal/provider/ssh_resource.go
@@ -149,12 +149,12 @@ func (r *SshResource) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 	sshRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/ssh", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	sshRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	sshRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating ssh key resource request", fmt.Sprintf("Error creating ssh key resource request: %s", err))
 		return
 	}
+	sshRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	sshRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	sshResponse, err := r.client.Do(sshRequest)
 	if err != nil {
@@ -194,12 +194,12 @@ func (r *SshResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 
 	sshRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/ssh/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	sshRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	sshRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating ssh key resource request", fmt.Sprintf("Error creating ssh key resource request: %s", err))
 		return
 	}
+	sshRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	sshRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	sshResponse, err := r.client.Do(sshRequest)
 	if err != nil {
@@ -271,12 +271,12 @@ func (r *SshResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	sshRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/ssh/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	sshRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	sshRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating ssh key resource request", fmt.Sprintf("Error creating ssh key resource request: %s", err))
 		return
 	}
+	sshRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	sshRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	sshResponse, err := r.client.Do(sshRequest)
 	if err != nil {
 		resp.Diagnostics.AddError("Error executing ssh key resource request", fmt.Sprintf("Error executing ssh key resource request: %s", err))
@@ -290,12 +290,12 @@ func (r *SshResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	sshRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/ssh/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	sshRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	sshRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating ssh key resource request", fmt.Sprintf("Error creating ssh key resource request: %s", err))
 		return
 	}
+	sshRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	sshRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	sshResponse, err = r.client.Do(sshRequest)
 	if err != nil {
@@ -339,11 +339,11 @@ func (r *SshResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	}
 
 	reqOrg, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/ssh/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), nil)
-	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating ssh key resource request", fmt.Sprintf("Error creating ssh key resource request: %s", err))
 		return
 	}
+	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(reqOrg)
 	if err != nil {

--- a/internal/provider/team_data_source.go
+++ b/internal/provider/team_data_source.go
@@ -180,11 +180,12 @@ func (d *TeamDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 func (d *TeamDataSource) ReadDataFromApi(url string, ctx context.Context, resp *datasource.ReadResponse, structType any) (data []interface{}) {
 	regApi, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating Team datasource request", fmt.Sprintf("Error creating Team datasource request: %s", err))
+		return
+	}
 	regApi.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	regApi.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, "Error creating Team datasource request")
-	}
 
 	resApi, err := d.client.Do(regApi)
 	if err != nil {

--- a/internal/provider/team_token_resource.go
+++ b/internal/provider/team_token_resource.go
@@ -163,12 +163,12 @@ func (r *TeamTokenResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	teamTokenRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/access-token/v1/teams", r.endpoint), strings.NewReader(string(bodyJson)))
-	teamTokenRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	teamTokenRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating team token resource request", fmt.Sprintf("Error creating team token resource request: %s", err))
 		return
 	}
+	teamTokenRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	teamTokenRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	teamTokenResponse, err := r.client.Do(teamTokenRequest)
 	if err != nil {
@@ -212,12 +212,12 @@ func (r *TeamTokenResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	teamTokenRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/access-token/v1/teams", r.endpoint), nil)
-	teamTokenRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	teamTokenRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating team token resource request", fmt.Sprintf("Error creating team token resource request: %s", err))
 		return
 	}
+	teamTokenRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	teamTokenRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	teamTokenResponse, err := r.client.Do(teamTokenRequest)
 	if err != nil {
@@ -287,11 +287,11 @@ func (r *TeamTokenResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	reqToken, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/access-token/v1/teams/%s", r.endpoint, data.ID.ValueString()), nil)
-	reqToken.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error deleting team token resource request", fmt.Sprintf("Error deleting team token resource request: %s", err))
 		return
 	}
+	reqToken.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	resToken, err := r.client.Do(reqToken)
 	if err != nil {

--- a/internal/provider/vcs_data_source.go
+++ b/internal/provider/vcs_data_source.go
@@ -127,12 +127,12 @@ func (d *VcsDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 
 	apiURL := fmt.Sprintf("%s/api/v1/organization/%s/vcs?filter[vcs]=name=='%s'", d.endpoint, state.OrganizationId.ValueString(), url.PathEscape(state.Name.ValueString()))
 	requestVcs, err := http.NewRequest(http.MethodGet, apiURL, nil)
-	requestVcs.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
-	requestVcs.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating ssh request", fmt.Sprintf("Error creating team resource request: %s", err))
 		return
 	}
+	requestVcs.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
+	requestVcs.Header.Add("Content-Type", "application/vnd.api+json")
 
 	responseVcs, err := d.client.Do(requestVcs)
 	if err != nil {

--- a/internal/provider/vcs_resource.go
+++ b/internal/provider/vcs_resource.go
@@ -225,12 +225,12 @@ func (r *VcsResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	vcsRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/vcs", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	vcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating VCS resource request", fmt.Sprintf("Error creating VCS resource request: %s", err))
 		return
 	}
+	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	vcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	vcsResponse, err := r.client.Do(vcsRequest)
 	if err != nil {
@@ -288,12 +288,12 @@ func (r *VcsResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	}
 
 	vcsRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/vcs/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	vcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating VCS resource request", fmt.Sprintf("Error creating VCS resource request: %s", err))
 		return
 	}
+	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	vcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	vcsResponse, err := r.client.Do(vcsRequest)
 	if err != nil {
@@ -382,12 +382,12 @@ func (r *VcsResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	tflog.Info(ctx, "Body Update Request: "+out.String())
 
 	vcsRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/vcs/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	vcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating VCS resource request", fmt.Sprintf("Error creating VCS resource request: %s", err))
 		return
 	}
+	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	vcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	vcsResponse, err := r.client.Do(vcsRequest)
 	if err != nil {
@@ -403,12 +403,12 @@ func (r *VcsResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	vcsRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/vcs/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	vcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating VCS resource request", fmt.Sprintf("Error creating VCS resource request: %s", err))
 		return
 	}
+	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	vcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	vcsResponse, err = r.client.Do(vcsRequest)
 	if err != nil {
@@ -467,11 +467,11 @@ func (r *VcsResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	}
 
 	vcsRequest, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/vcs/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), nil)
-	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating VCS resource request", fmt.Sprintf("Error creating VCS resource request: %s", err))
 		return
 	}
+	vcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	vcsResponse, err := r.client.Do(vcsRequest)
 	if err != nil {

--- a/internal/provider/workspace_cli_resource.go
+++ b/internal/provider/workspace_cli_resource.go
@@ -177,12 +177,12 @@ func (r *WorkspaceCliResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	workspaceCliRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/workspace", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	workspaceCliRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceCliRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace cli resource request", fmt.Sprintf("Error creating workspace cli resource request: %s", err))
 		return
 	}
+	workspaceCliRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceCliRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceCliResponse, err := r.client.Do(workspaceCliRequest)
 	if err != nil {
@@ -232,12 +232,12 @@ func (r *WorkspaceCliResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	workspaceRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace cli resource request", fmt.Sprintf("Error creating workspace cli resource request: %s", err))
 		return
 	}
+	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceResponse, err := r.client.Do(workspaceRequest)
 	if err != nil {
@@ -328,12 +328,12 @@ func (r *WorkspaceCliResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	organizationRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace cli resource request", fmt.Sprintf("Error creating workspace cli resource request: %s", err))
 		return
 	}
+	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationResponse, err := r.client.Do(organizationRequest)
 	if err != nil {
@@ -349,12 +349,12 @@ func (r *WorkspaceCliResource) Update(ctx context.Context, req resource.UpdateRe
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	organizationRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace cli resource request", fmt.Sprintf("Error creating workspace cli resource request: %s", err))
 		return
 	}
+	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationResponse, err = r.client.Do(organizationRequest)
 	if err != nil {
@@ -444,12 +444,12 @@ func (r *WorkspaceCliResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	workspaceCliRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), strings.NewReader(out.String()))
-	workspaceCliRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceCliRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating cli resource request", fmt.Sprintf("Error creating cli resource request: %s", err))
 		return
 	}
+	workspaceCliRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceCliRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceCliResponse, err := r.client.Do(workspaceCliRequest)
 	if err != nil {

--- a/internal/provider/workspace_data_source.go
+++ b/internal/provider/workspace_data_source.go
@@ -172,11 +172,12 @@ func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 	req.Config.Get(ctx, &state)
 
 	reqOrg, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization?filter[organization]=name==%s", d.endpoint, state.Organization.ValueString()), nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating Workspace datasource request", fmt.Sprintf("Error creating Workspace datasource request: %s", err))
+		return
+	}
 	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	reqOrg.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, "Error creating Workspace datasource request")
-	}
 
 	resOrg, err := d.client.Do(reqOrg)
 	if err != nil {
@@ -213,11 +214,12 @@ func (d *WorkspaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 
 	//now try to find the workspace
 	reqWS, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace?filter[workspace]=name==%s", d.endpoint, state.OrganizationID.ValueString(), state.Name.ValueString()), nil)
+	if err != nil {
+		resp.Diagnostics.AddError("Error creating Workspace datasource request part 2", fmt.Sprintf("Error creating Workspace datasource request part 2: %s", err))
+		return
+	}
 	reqWS.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.token))
 	reqWS.Header.Add("Content-Type", "application/vnd.api+json")
-	if err != nil {
-		tflog.Error(ctx, "Error creating Workspace datasource request part 2")
-	}
 
 	resWS, err := d.client.Do(reqWS)
 	if err != nil {

--- a/internal/provider/workspace_schedule_resource.go
+++ b/internal/provider/workspace_schedule_resource.go
@@ -130,12 +130,12 @@ func (r *WorkspaceScheduleResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	workspaceScheduleRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/workspace/%s/schedule", r.endpoint, plan.WorkspaceId.ValueString()), strings.NewReader(out.String()))
-	workspaceScheduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceScheduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace schedule resource request", fmt.Sprintf("Error creating workspace schedule resource request: %s", err))
 		return
 	}
+	workspaceScheduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceScheduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceScheduleResponse, err := r.client.Do(workspaceScheduleRequest)
 	if err != nil {
@@ -178,12 +178,12 @@ func (r *WorkspaceScheduleResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	workspaceScheduleRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/workspace/%s/schedule/%s", r.endpoint, state.WorkspaceId.ValueString(), state.ID.ValueString()), nil)
-	workspaceScheduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceScheduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace schedule resource request", fmt.Sprintf("Error creating workspace schedule resource request: %s", err))
 		return
 	}
+	workspaceScheduleRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceScheduleRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceScheduleResponse, err := r.client.Do(workspaceScheduleRequest)
 	if err != nil {
@@ -252,12 +252,12 @@ func (r *WorkspaceScheduleResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	workspaceScheduleReq, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/workspace/%s/schedule/%s", r.endpoint, state.WorkspaceId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	workspaceScheduleReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceScheduleReq.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Workspace schedule resource request", fmt.Sprintf("Error creating schedule schedule resource request: %s", err))
 		return
 	}
+	workspaceScheduleReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceScheduleReq.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceScheduleResponse, err := r.client.Do(workspaceScheduleReq)
 	if err != nil {
@@ -273,12 +273,12 @@ func (r *WorkspaceScheduleResource) Update(ctx context.Context, req resource.Upd
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	workspaceScheduleReq, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/workspace/%s/schedule/%s", r.endpoint, state.WorkspaceId.ValueString(), state.ID.ValueString()), nil)
-	workspaceScheduleReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceScheduleReq.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Workspace schedule resource request", fmt.Sprintf("Error creating Workspace schedule resource request: %s", err))
 		return
 	}
+	workspaceScheduleReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceScheduleReq.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceScheduleResponse, err = r.client.Do(workspaceScheduleReq)
 	if err != nil {
@@ -319,11 +319,11 @@ func (r *WorkspaceScheduleResource) Delete(ctx context.Context, req resource.Del
 	}
 
 	workspaceRequest, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/workspace/%s/schedule/%s", r.endpoint, data.WorkspaceId.ValueString(), data.ID.ValueString()), nil)
-	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Workspace schedule resource request", fmt.Sprintf("Error creating schedule schedule resource request: %s", err))
 		return
 	}
+	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(workspaceRequest)
 	if err != nil {

--- a/internal/provider/workspace_tag_resource.go
+++ b/internal/provider/workspace_tag_resource.go
@@ -128,12 +128,12 @@ func (r *WorkspaceTagResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	workspaceTagRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/workspaceTag", r.endpoint, plan.OrganizationId.ValueString(), plan.WorkspaceId.ValueString()), strings.NewReader(out.String()))
-	workspaceTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace tag resource request", fmt.Sprintf("Error creating workspace tag resource request: %s", err))
 		return
 	}
+	workspaceTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceTagResponse, err := r.client.Do(workspaceTagRequest)
 	if err != nil {
@@ -177,12 +177,12 @@ func (r *WorkspaceTagResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	workspaceTagRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/workspaceTag/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), nil)
-	workspaceTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace tag resource request", fmt.Sprintf("Error creating workspace tag resource request: %s", err))
 		return
 	}
+	workspaceTagRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceTagRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceTagResponse, err := r.client.Do(workspaceTagRequest)
 	if err != nil {
@@ -236,11 +236,11 @@ func (r *WorkspaceTagResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	reqOrg, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/workspaceTag/%s", r.endpoint, data.OrganizationId.ValueString(), data.WorkspaceId.ValueString(), data.TagID.ValueString()), nil)
-	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace tag resource request", fmt.Sprintf("Error creating workspace tag resource request: %s", err))
 		return
 	}
+	reqOrg.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(reqOrg)
 	if err != nil {

--- a/internal/provider/workspace_variable_resource.go
+++ b/internal/provider/workspace_variable_resource.go
@@ -159,12 +159,12 @@ func (r *WorkspaceVariableResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	workspaceVarRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/variable", r.endpoint, plan.OrganizationId.ValueString(), plan.WorkspaceId.ValueString()), strings.NewReader(out.String()))
-	workspaceVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace variable resource request", fmt.Sprintf("Error creating workspace variable resource request: %s", err))
 		return
 	}
+	workspaceVarRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceVarRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceVarResponse, err := r.client.Do(workspaceVarRequest)
 	if err != nil {
@@ -216,12 +216,12 @@ func (r *WorkspaceVariableResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	workspaceVariableRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/variable/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), nil)
-	workspaceVariableRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceVariableRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace variable resource request", fmt.Sprintf("Error creating workspace variable resource request: %s", err))
 		return
 	}
+	workspaceVariableRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceVariableRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceVariableResponse, err := r.client.Do(workspaceVariableRequest)
 	if err != nil {
@@ -305,12 +305,12 @@ func (r *WorkspaceVariableResource) Update(ctx context.Context, req resource.Upd
 	}
 
 	workspaceVariableReq, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/variable/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	workspaceVariableReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceVariableReq.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Workspace variable resource request", fmt.Sprintf("Error creating Workspace variable resource request: %s", err))
 		return
 	}
+	workspaceVariableReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceVariableReq.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceVariableResponse, err := r.client.Do(workspaceVariableReq)
 	if err != nil {
@@ -326,12 +326,12 @@ func (r *WorkspaceVariableResource) Update(ctx context.Context, req resource.Upd
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	workspaceVariableReq, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/variable/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), nil)
-	workspaceVariableReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceVariableReq.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Workspace variable resource request", fmt.Sprintf("Error creating Workspace variable resource request: %s", err))
 		return
 	}
+	workspaceVariableReq.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceVariableReq.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceVariableResponse, err = r.client.Do(workspaceVariableReq)
 	if err != nil {
@@ -383,11 +383,11 @@ func (r *WorkspaceVariableResource) Delete(ctx context.Context, req resource.Del
 	}
 
 	workspaceRequest, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/variable/%s", r.endpoint, data.OrganizationId.ValueString(), data.WorkspaceId.ValueString(), data.ID.ValueString()), nil)
-	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Workspace variable resource request", fmt.Sprintf("Error creating Workspace variable resource request: %s", err))
 		return
 	}
+	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	_, err = r.client.Do(workspaceRequest)
 	if err != nil {

--- a/internal/provider/workspace_vcs_resource.go
+++ b/internal/provider/workspace_vcs_resource.go
@@ -254,12 +254,12 @@ func (r *WorkspaceVcsResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	workspaceVcsRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/workspace", r.endpoint, plan.OrganizationId.ValueString()), strings.NewReader(out.String()))
-	workspaceVcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceVcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace vcs resource request", fmt.Sprintf("Error creating workspace vcs resource request: %s", err))
 		return
 	}
+	workspaceVcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceVcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceVcsResponse, err := r.client.Do(workspaceVcsRequest)
 	if err != nil {
@@ -330,12 +330,12 @@ func (r *WorkspaceVcsResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	workspaceRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace vcs resource request", fmt.Sprintf("Error creating workspace cli resource request: %s", err))
 		return
 	}
+	workspaceRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceResponse, err := r.client.Do(workspaceRequest)
 	if err != nil {
@@ -456,12 +456,12 @@ func (r *WorkspaceVcsResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	organizationRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace vcs resource request", fmt.Sprintf("Error creating workspace vcs resource request: %s", err))
 		return
 	}
+	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationResponse, err := r.client.Do(organizationRequest)
 	if err != nil {
@@ -477,12 +477,12 @@ func (r *WorkspaceVcsResource) Update(ctx context.Context, req resource.UpdateRe
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	organizationRequest, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s", r.endpoint, state.OrganizationId.ValueString(), state.ID.ValueString()), nil)
-	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace vcs resource request", fmt.Sprintf("Error creating workspace vcs resource request: %s", err))
 		return
 	}
+	organizationRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	organizationRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	organizationResponse, err = r.client.Do(organizationRequest)
 	if err != nil {
@@ -587,12 +587,12 @@ func (r *WorkspaceVcsResource) Delete(ctx context.Context, req resource.DeleteRe
 	}
 
 	workspaceVcsRequest, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s", r.endpoint, data.OrganizationId.ValueString(), data.ID.ValueString()), strings.NewReader(out.String()))
-	workspaceVcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	workspaceVcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating vcs resource request", fmt.Sprintf("Error creating vcs resource request: %s", err))
 		return
 	}
+	workspaceVcsRequest.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	workspaceVcsRequest.Header.Add("Content-Type", "application/vnd.api+json")
 
 	workspaceVcsResponse, err := r.client.Do(workspaceVcsRequest)
 	if err != nil {

--- a/internal/provider/workspace_webhook_resource.go
+++ b/internal/provider/workspace_webhook_resource.go
@@ -168,12 +168,12 @@ func (r *WorkspaceWebhookResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	request, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook", r.endpoint, plan.OrganizationId.ValueString(), plan.WorkspaceId.ValueString()), strings.NewReader(out.String()))
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	request.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace webhook resource request", fmt.Sprintf("Error creating workspace webhook resource request %s", err))
 		return
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	request.Header.Add("Content-Type", "application/vnd.api+json")
 
 	response, err := r.client.Do(request)
 	if err != nil {
@@ -217,12 +217,12 @@ func (r *WorkspaceWebhookResource) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), nil)
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	request.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace webhook resource request", fmt.Sprintf("Error creating workspace webhook resource request: %s", err))
 		return
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	request.Header.Add("Content-Type", "application/vnd.api+json")
 
 	response, err := r.client.Do(request)
 	if err != nil {
@@ -300,12 +300,12 @@ func (r *WorkspaceWebhookResource) Update(ctx context.Context, req resource.Upda
 	}
 
 	request, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	request.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating Workspace variable resource request", fmt.Sprintf("Error creating Workspace variable resource request: %s", err))
 		return
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	request.Header.Add("Content-Type", "application/vnd.api+json")
 
 	response, err := r.client.Do(request)
 	if err != nil {
@@ -321,12 +321,12 @@ func (r *WorkspaceWebhookResource) Update(ctx context.Context, req resource.Upda
 	tflog.Info(ctx, "Body Response", map[string]any{"success": string(bodyResponse)})
 
 	request, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), nil)
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	request.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace webhook resource request", fmt.Sprintf("Error creating workspace webhook resource request: %s", err))
 		return
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	request.Header.Add("Content-Type", "application/vnd.api+json")
 
 	response, err = r.client.Do(request)
 	if err != nil {
@@ -370,11 +370,11 @@ func (r *WorkspaceWebhookResource) Delete(ctx context.Context, req resource.Dele
 	}
 
 	request, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook/%s", r.endpoint, data.OrganizationId.ValueString(), data.WorkspaceId.ValueString(), data.ID.ValueString()), nil)
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace webhook resource request", fmt.Sprintf("Error creating workspace webhook resource request: %s", err))
 		return
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	response, err := r.client.Do(request)
 	if err != nil {

--- a/internal/provider/workspace_webhook_v2_resource.go
+++ b/internal/provider/workspace_webhook_v2_resource.go
@@ -369,12 +369,12 @@ func (r *WorkspaceWebhookV2Resource) Update(ctx context.Context, req resource.Up
 	}
 
 	request, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), strings.NewReader(out.String()))
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	request.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace webhook resource request", fmt.Sprintf("Error creating workspace webhook resource request: %s", err))
 		return
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	request.Header.Add("Content-Type", "application/vnd.api+json")
 
 	response, err := r.client.Do(request)
 	if err != nil {
@@ -402,12 +402,12 @@ func (r *WorkspaceWebhookV2Resource) Update(ctx context.Context, req resource.Up
 	}
 
 	request, err = http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook/%s", r.endpoint, state.OrganizationId.ValueString(), state.WorkspaceId.ValueString(), state.ID.ValueString()), nil)
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
-	request.Header.Add("Content-Type", "application/vnd.api+json")
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace webhook resource request", fmt.Sprintf("Error creating workspace webhook resource request: %s", err))
 		return
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
+	request.Header.Add("Content-Type", "application/vnd.api+json")
 
 	response, err = r.client.Do(request)
 	if err != nil {
@@ -460,11 +460,11 @@ func (r *WorkspaceWebhookV2Resource) Delete(ctx context.Context, req resource.De
 	}
 
 	request, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/api/v1/organization/%s/workspace/%s/webhook/%s", r.endpoint, data.OrganizationId.ValueString(), data.WorkspaceId.ValueString(), data.ID.ValueString()), nil)
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating workspace webhook resource request", fmt.Sprintf("Error creating workspace webhook resource request: %s", err))
 		return
 	}
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", r.token))
 
 	response, err := r.client.Do(request)
 	if err != nil {


### PR DESCRIPTION
Follow-up to #158, as mentioned in that PR's description.

Every request builder added headers to the request before checking the http.NewRequest error, so a request-construction failure (for example a malformed endpoint URL) dereferenced a nil request and crashed the plugin instead of surfacing a diagnostic.

This reorders all 101 sites to check the error first, and upgrades the ten error branches that only logged without returning to return a proper diagnostic, following the same pattern as #158.

Verified with a dev-override plan against a malformed endpoint URL: before, the plugin crashed; after, the plan fails cleanly with 'Error creating organization tag datasource request: parse ...: invalid character " " in host name'. go build, go vet and the provider unit tests pass; a full re-scan confirms zero remaining header-before-error-check sites.